### PR TITLE
Rename Hybrid Cluster to ClusterHQ

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -2112,7 +2112,7 @@ name = zombofant.net
 name = Jim Baker
 
 [https://clusterhq.com/blog/feed/?tag=python]
-name = Hybrid Cluster
+name = ClusterHQ
 
 [https://hynek.me/feed-python.xml]
 name = Hynek Schlawack


### PR DESCRIPTION
Hybrid Cluster has been renamed to ClusterHQ. The Hybrid Cluster project has been discontinued.