### PR TITLE
Add Sumith's Blog

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -1568,6 +1568,9 @@ name = Mathieu Fenniak
 [http://strombrg.blogspot.com/feeds/posts/default/-/Python]
 name = Dan Stromberg
 
+[http://sumith1896.github.io/feeds/feed.sympy.xml]
++name = Sumith - Blog about SymPy/Python
+
 [http://swaroopch.com/tag/python/feed/]
 name = Swaroop C H
 


### PR DESCRIPTION
Blog about SymPy/SymEngine progress. The feed sends posts with SymPy tag. Started for Google Summer of Code progress under Python Software Foundations.
Got a mail from Terri saying that the aggregator he set up http://terri.toybox.ca/python-soc/ for GSoC students under PSF has a invalid feed for my blog. It is also linked with http://planetpython.org/.
Hence this PR.