### PR TITLE
Update Python feed of ClusterHQ

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -2159,7 +2159,7 @@ name = zombofant.net
 [http://zyasoft.com/pythoneering/atom.xml]
 name = Jim Baker
 
-[https://clusterhq.com/blog/feed/?tag=python]
+[https://clusterhq.com/feed.python.xml]
 name = ClusterHQ
 
 [https://hynek.me/feed-python.xml]


### PR DESCRIPTION
This is in preparation for the site migration to Jekyll.

Currently the website is on Wordpress. 

I have added a 302 for `/feed.python.xml` to go to `/blog/feed/?tag=python`, please don't merge this if you can not follow 302's. In this case we can work out another way to get the feed to `/feed.python.xml`.

In the near future `feed.python.xml` will not redirect, and will produce RSS.