### PR TITLE
Correct EuroPython blog entries

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -187,7 +187,7 @@ name = End Point
 name = Enthought
 
 [http://blog.europython.eu/rss]
-name = Europython
+name = EuroPython
 
 [http://blog.extracheese.org/feeds/posts/default/-/python]
 name = Gary Bernhardt
@@ -599,9 +599,6 @@ name = Eric Holscher
 
 [http://etienned.github.io/categories/python.xml]
 name = Etienne Desautels
-
-[http://europython.eu/blog/feeds/full/]
-name = EuroPython
 
 [http://evennia.blogspot.com/feeds/posts/default]
 name = Evennia


### PR DESCRIPTION
The official blog is http://blog.europython.eu/. The older entry is no longer in use.
Correct the spelling.