### PR TITLE
adding Python Does What

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -1403,6 +1403,9 @@ name = PythonClub - A Brazilian collaborative blog about Python
 [http://pythonconquerstheuniverse.wordpress.com/feed/atom/]
 name = Stephen Ferg
 
+[http://pythondoeswhat.blogspot.com/feeds/posts/default]
+name = Python Does What?!
+
 [http://pythonfilter.com/rss.xml]
 name = "Eric Wu's Pythonfilter"
 


### PR DESCRIPTION
Adding [Python Does What](http://pythondoeswhat.blogspot.com/), a little blog about Python corner cases and oddities.