### PR TITLE
Add Python feed for treyhunner.com

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -1682,6 +1682,9 @@ name = Tomer Filiba
 [http://tonybreyal.wordpress.com/category/python/feed/atom/]
 name = Tony Breyal
 
+[http://treyhunner.com/python.xml]
+name = Trey Hunner
+
 [http://txzone.net/category/python/feed]
 name = Mathieu Virbel
 


### PR DESCRIPTION
I have been blogging about Python off-and-on for a few years now.  A reader suggested that I ask to have my blog syndicated by Planet Python.  Here is my request to do so. :smile_cat: 

- Feed is Python-specific
- Feed is English-language only

Thank you! :balloon: 