### PR TITLE
Adding Semaphore Community Python feed

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -90,9 +90,6 @@ name = Jean-Paul Calderone
 [http://astrocodeschool.com/feeds/all.rss.xml]
 name = Astro Code School
 
-[http://www.codemakesmehappy.com/feeds/posts/default/-/Python]
-name = Audrey Roy Greenfeld
-
 [http://avelino.xxx/python-en/feed]
 name = Thiago Avelino
 
@@ -1823,6 +1820,9 @@ name = Christopher Lenz
 [http://www.codeforcloud.info/blog/categories/python/atom.xml]
 name = Code for Cloud
 
+[http://www.codemakesmehappy.com/feeds/posts/default/-/Python]
+name = Audrey Roy Greenfeld
+
 [http://www.coresoftwaregroup.com/blog/topics/python/@@rss.xml]
 name = Core Software
 
@@ -2224,6 +2224,9 @@ name = Brett Cannon
 
 [https://nvbn.github.io/feed.python.xml]
 name = Vladimir Iakolev
+
+[https://semaphoreci.com/community/tags/python.atom]
+name = Semaphore Community
 
 [https://www.codementor.io/python/tutorial/feed/]
 name = Codementor


### PR DESCRIPTION
Name: Semaphore Community 
Link: https://semaphoreci.com/community/tags/python
Feed url: https://semaphoreci.com/community/tags/python.atom