### PR TITLE
Update link to my feed, second time

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -585,7 +585,7 @@ name = John Jacobsen
 [http://eli.thegreenplace.net/feeds/python.atom.xml]
 name = Eli Bendersky
 
-[http://emptysqua.re/blog/category/python/feed/]
+[https://emptysqua.re/blog/category/python/feed/index.xml]
 name = A. Jesse Jiryu Davis
 
 [http://en.ig.ma/notebook/feeds/atom/tag/python.xml]


### PR DESCRIPTION
I've re-enabled HTTPS on my site, and I think it's best to point the URL directly at my feed file.