### PR TITLE
Use https instead of http for treyhunner.com

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -1709,7 +1709,7 @@ name = Tomer Filiba
 [http://tonybreyal.wordpress.com/category/python/feed/atom/]
 name = Tony Breyal
 
-[http://treyhunner.com/python.xml]
+[https://treyhunner.com/python.xml]
 name = Trey Hunner
 
 [http://txzone.net/category/python/feed]


### PR DESCRIPTION
The blog post I published earlier isn't in the Planet Python feed. Is it because I switched my website to HTTPS and it doesn't follow redirects?