### PR TITLE
Remove SSL for treyhunner.com

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -2276,7 +2276,7 @@ name = Real Python
 [https://semaphoreci.com/community/tags/python.atom]
 name = Semaphore Community
 
-[https://treyhunner.com/python.xml]
+[http://treyhunner.com/python.xml]
 name = Trey Hunner
 
 [https://www.codementor.io/python/tutorial/feed/]


### PR DESCRIPTION
Per #114. This should finally fix my feed issues.

If I re-enable SSL in the future, will the redirect be followed automatically?