### PR TITLE
New RSS URL due to blog engine change

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -1094,7 +1094,7 @@ name = Michael Droettboom
 [http://metachris.org/category/python/feed/atom/]
 name = Chris Hager
 
-[http://mg.pov.lt/blog/index.rss]
+[http://mg.pov.lt/blog/index.xml]
 name = Marius Gedminas
 
 [http://michael.susens-schurter.com/blog/category/technology/python/feed]


### PR DESCRIPTION
# EDIT FEED
------------------------------------------------------------------------------
Hi, I want to change my current feed url from http://mg.pov.lt/blog/index.rss to http://mg.pov.lt/blog/index.xml

## I checked the following required validations:

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=MY_FEED_URL and it is valid!
2. [ ] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [ ] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)

Thanks in advance for changing my feed on Python Planet! :+1:

Other notes:

I've switched my blog from Pyblosxom to Hugo, and the RSS feed URL changed.

I see you're limiting new feed items to 1, which is excellent, as it means the planet shouldn't be flooded with old posts.  Hopefully.  There's exactly one new post at the new feed URL.

Um.  Except if you really want a tagged URL, which would be http://mg.pov.lt/blog/tags/python/index.xml, then that feed has no new posts and I don't want to resurrect ancient posts and uh.  I can blog about something Python specific and submit a PR then, if you want?