### PR TITLE
adding PayPal Engineering's Python feed to config.ini

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -2333,6 +2333,8 @@ name = Moya Project
 [https://www.neckbeardrepublic.com/rss/]
 name = Neckbeard Republic
 
+[https://www.paypal-engineering.com/tag/python/feed/]
+name = PayPal Engineering Blog
+
 [https://www.pytexas.org/blog.rss]
 name = PyTexas
-


### PR DESCRIPTION
# ADD FEED
-------------------------------------------------------------------------------

Hi, I want to add my feed to the Python Planet.

## I checked the following required validations: (mark all 4 with [x])

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=https://www.paypal-engineering.com/tag/python/feed/ and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)

Thanks in advance for adding my feed to the PythonPlanet! :+1:
