### PR TITLE
Add qutebrowser development blog

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -306,6 +306,9 @@ name = Eve REST Framework
 [http://blog.pythonanywhere.com/feed/]
 name = Python Anywhere
 
+[http://blog.qutebrowser.org/feeds/tag-pyplanet.rss.xml]
+name = qutebrowser development blog
+
 [http://blog.randell.ph/tag/python/feed/atom/]
 name = Randell Benavidez
 


### PR DESCRIPTION
Hi, I want to add my feed to the Python Planet.

## I checked the following required validations: (mark all 4 with [x])

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=http://blog.qutebrowser.org/feeds/tag-pyplanet.rss.xml and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url *(I added a `pyplanet` tag as I plan to post daily-ish updates which - while all related to python in some way - might be too much.)*
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)

Thanks in advance for adding my feed to the PythonPlanet! :+1: