### PR TITLE
Update Eric Holscher's feed URL

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -630,7 +630,7 @@ name = Eniram Ltd.
 [http://entitycrisis.blogspot.com/feeds/posts/default/-/Python]
 name = Simon Wittber
 
-[http://ericholscher.com/feeds/cat/python/]
+[http://ericholscher.com/blog/archive/tag/python/atom.xml]
 name = Eric Holscher
 
 [http://etienned.github.io/categories/python.xml]


### PR DESCRIPTION
# EDIT FEED
------------------------------------------------------------------------------
Hi, I want to change my current feed url from http://ericholscher.com/feeds/cat/python/ to http://ericholscher.com/blog/archive/tag/python/atom.xml

## I checked the following required validations:  (mark all 4 with [x])

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=MY_FEED_URL and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)

Thanks in advance for changing my feed on Python Planet! :+1:
