### PR TITLE
Updated feed address for Abu Ashraf Masnun

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -1097,7 +1097,7 @@ name = Mark Paschal
 [http://martinfitzpatrick.name/feeds/python.tag.atom.xml]
 name = Martin Fitzpatrick
 
-[http://masnun.com/category/python/feed/]
+[http://masnun.rocks/tags/python/index.xml]
 name = Abu Ashraf Masnun
 
 [http://mattgoodall.blogspot.com/atom.xml]


### PR DESCRIPTION

#  EDIT FEED
------------------------------------------------------------------------------
The blog I have at http://masnun.com contains content in both English and Bangla (my native language). To avoid any localized contents getting syndicated in planet python, I have started a new blog where I will be publishing contents only in English.

Old URL: http://masnun.com/category/python/feed/ 
New URL: http://masnun.rocks/tags/python/index.xml

## I checked the following required validations:  (mark all 4 with [x])

1. [x ] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=http://masnun.rocks/tags/python/index.xml and it is valid!
2. [x ] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x ] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x ] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)

Thanks in advance for changing my feed on Python Planet! :+1:

