### PR TITLE
Update link to my feed

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -2327,7 +2327,7 @@ name = ClusterHQ
 [https://cobe.io/blog/categories/python.xml]
 name = Cobe.io
 
-[https://emptysqua.re/blog/category/python/feed/index.xml]
+[https://emptysqua.re/blog/category/python/index.xml]
 name = A. Jesse Jiryu Davis
 
 [https://hynek.me/feed-python.xml]


### PR DESCRIPTION
# EDIT FEED
------------------------------------------------------------------------------
Hi, I want to change my current feed url from https://emptysqua.re/blog/category/python/feed/index.xml to https://emptysqua.re/blog/category/python/index.xml

(The "feed" part of the path is gone.)

## I checked the following required validations:  (mark all 4 with [x])

1. [x ] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=https://emptysqua.re/blog/category/python/index.xml and it is valid!
2. [ x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [ x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x ] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)

Thanks in advance for changing my feed on Python Planet! :+1:
