### PR TITLE
Update URL for flaper87's blog

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -207,7 +207,7 @@ name = Filipe Saraiva
 [http://blog.fizyk.net.pl/tags/python.xml]
 name = Grzegorz Śliwiński
 
-[http://blog.flaper87.org/feeds/latest/tag/python/]
+[http://blog.flaper87.com/feeds/latest/tag/python/]
 name = Flavio Percoco
 
 [http://blog.garage-coding.com/tag/python/feed.xml]


### PR DESCRIPTION
# EDIT FEED
------------------------------------------------------------------------------
Hi, I want to change my current feed url from `blog.flaper87.org` to `blog.flaper87.com`

## I checked the following required validations: 

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=http://blog.flaper87.com/feeds/latest/tag/python and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)

Thanks in advance for changing my feed on Python Planet! :+1:
