### PR TITLE
Update config.ini

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -696,7 +696,7 @@ name = Twisted Matrix Labs
 [http://feeds.feedburner.com/WebInfrastructureSystemsDeploymentsAndTechnologiesPython]
 name = Jeff McNeil
 
-[http://feeds.feedburner.com/aclark/python]
+[http://blog.aclark.net/blog/category/python/atom.xml]
 name = Alex Clark
 
 [http://feeds.feedburner.com/btbytes_python]


### PR DESCRIPTION
# EDIT FEED
------------------------------------------------------------------------------
Hi, I want to change my current feed url from http://feeds.feedburner.com/aclark/python to http://blog.aclark.net/blog/category/python/atom.xml

## I checked the following required validations:  (mark all 4 with [x])

1. [X] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=MY_FEED_URL and it is valid!
2. [X] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [X] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [X] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)

Thanks in advance for changing my feed on Python Planet! :+1: