### PR TITLE
Update RSS feed.

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -1949,7 +1949,7 @@ name = Mitchell Garnaat
 [http://www.endlesslycurious.com/tag/python/feed/]
 name = Daniel Brown
 
-[http://www.eshlox.net/en/feed/category/python/]
+[https://eshlox.net/tag/python/rss/index.xml]
 name = Przemysław Kołodziejczyk
 
 [http://www.europython-society.org/rss]


### PR DESCRIPTION
Hi, I want to change my current feed url from http://www.eshlox.net/en/feed/category/python/ to https://eshlox.net/tag/python/rss/index.xml

## I checked the following required validations:  (mark all 4 with [x])

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=https://eshlox.net/tag/python/rss/index.xml and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)

Thanks in advance for changing my feed on Python Planet! :+1: