### PR TITLE
Update python RSS feed for my website

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -1211,7 +1211,7 @@ name = Nick Janetakis
 [http://nicoddemus.github.io/tag/python/atom.xml]
 name = Bruno Oliveira
 
-[http://nicolaiarocci.com/tag/python/feed]
+[http://nicolaiarocci.com/tags/python/index.xml]
 name = Nicola Iarocci
 
 [http://nigelb.me/python.xml]


### PR DESCRIPTION
EDIT FEED
------------------------------------------------------------------------------
Hi,

I switched from WordPress to Hugo static site generator, which involves a RSS feed URL change. This pull requests fixes the URL feed on planetpython.org. 

## I checked the following required validations:  (mark all 4 with [x])

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=MY_FEED_URL and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)

Thanks in advance for changing my feed on Python Planet! :+1: