### PR TITLE
Back out Codementor feed

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -2396,9 +2396,6 @@ name = Stories in My Pocket
 [https://wearpants.org/feeds/petecode.xml?tag=python]
 name = Petecode
 
-[https://www.codementor.io/python/tutorial/feed/]
-name = Codementor
-
 [https://www.datacamp.com/community/blog/python-feed.rss]
 name = DataCamp
 


### PR DESCRIPTION
The feed changes the `updated` field of old posts frequently, re-pushing all its Python-related articles to the top of the planet.

@alpaca-power, please let us know when you have fixed that issue, and I will revert this change.

Closes #97, #190.