### PR TITLE
Revert "Back out Codementor feed"

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -2396,6 +2396,9 @@ name = Stories in My Pocket
 [https://wearpants.org/feeds/petecode.xml?tag=python]
 name = Petecode
 
+[https://www.codementor.io/python/tutorial/feed/]
+name = Codementor
+
 [https://www.datacamp.com/community/blog/python-feed.rss]
 name = DataCamp
 


### PR DESCRIPTION
Reverts python/planet#191

I've checked, and the `<updated>` element is now correct (matches the publication date for each item, rather than the last item).