### PR TITLE
Add pfertyk.me atom feed

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -1292,6 +1292,9 @@ name = Peter Eisentraut
 [http://petro.tanrei.ca/categories/python/feed.atom]
 name = Petro Verkhogliad
 
+[http://pfertyk.me/feeds/python.atom.xml]
+name = Paweł Fertyk
+
 [http://pgcli.com/feeds/tag.python.atom.xml]
 name = pgcli
 


### PR DESCRIPTION
Hi, I want to add my feed to the Python Planet.

## I checked the following required validations: (mark all 4 with [x])

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=MY_FEED_URL and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)

Thanks in advance for adding my feed to the PythonPlanet! :+1: