### PR TITLE
Add simpleisbetterthancomplex.com rss feed

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -2414,6 +2414,9 @@ name = Sayan Chowdhury
 [https://semaphoreci.com/community/tags/python.atom]
 name = Semaphore Community
 
+[https://simpleisbetterthancomplex.com/feed.xml]
+name = Simple is Better Than Complex
+
 [https://snarky.ca/rss/]
 name = Brett Cannon
 
@@ -2453,8 +2456,9 @@ name = PyTexas
 [https://www.rosehosting.com/blog/tag/python/feed/]
 name = RoseHosting Blog
 
+[https://www.starzel.de/blog/starzel-de-python-blog/RSS]
+name = Starzel.de
+
 [https://yoongkang.com/feeds/all.atom.xml]
 name = Yoong Kang Lim
 
-[https://www.starzel.de/blog/starzel-de-python-blog/RSS]
-name = Starzel.de


### PR DESCRIPTION
Hi, I want to add my feed to the Python Planet.

## I checked the following required validations:

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=https://simpleisbetterthancomplex.com/feed.xml and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)

Thanks in advance for adding my feed to the PythonPlanet! :+1: