### PR TITLE
Updated feed URL for Daniel Roy Greenfeld

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -1373,7 +1373,7 @@ name = Benjamin Peterson
 [http://pycloud.blogspot.com/feeds/posts/default/-/python]
 name = Gökhan Sever
 
-[http://pydanny.github.com/feeds/python.atom.xml]
+[https://www.pydanny.com/feeds/python.atom.xml]
 name = Daniel Roy Greenfeld
 
 [http://pydev.blogspot.com/atom.xml]


### PR DESCRIPTION
# EDIT FEED
------------------------------------------------------------------------------
Hi, I want to change my current feed url from http://pydanny.github.com/feeds/python.atom.xml to https://www.pydanny.com/feeds/python.atom.xml

## I checked the following required validations:  (mark all 4 with [x])

1. [X] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=https://www.pydanny.com/feeds/python.atom.xml and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)

Thanks in advance for changing my feed on Python Planet! :+1: