### PR TITLE
Fix #128 Order feed entried by blog name

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -15,41 +15,53 @@ link = http://planetpython.org/
 template_files = config/index.html.tmpl config/rss20.xml.tmpl config/rss10.xml.tmpl config/opml.xml.tmpl config/foafroll.xml.tmpl config/summary.html.tmpl config/titles_only.html.tmpl
 cache_directory = /srv/cache
 
-[guilhermetoti.com.br/feeds/all.atom.xml]
-name = Guilherme Toti
+[http://www.2general.com/blog/python.rss.html]
+name = 2General
 
-[http://1stvamp.org/tag/python/atom/]
-name = Wes Mason
+[http://dev.2degreesnetwork.com/feeds/posts/default/-/python]
+name = 2degrees
 
-[http://TuringFinance.com/category/python/feed/]
-name = Stuart Gordon Reid
-
-[http://ablog.readthedocs.org/blog/atom.xml]
-name = ABlog for Sphinx
-
-[http://aboutsimon.com/category/python/feed/atom/]
-name = Simon
-
-[http://adrian.org.ar/tag/python/feed/atom/]
-name = Adrián Deccico
+[http://devblog.4teamwork.ch/blog/categories/planet-python/atom.xml]
+name = 4teamwork
 
 [http://advocacy.python.org/podcasts/littlebit.rss]
 name = A Little Bit of Python
 
-[http://advocacy.python.org/podcasts/pycon.rss]
-name = PyCon Podcast
+[https://emptysqua.re/blog/category/python/index.xml]
+name = A. Jesse Jiryu Davis
+
+[http://ablog.readthedocs.org/blog/atom.xml]
+name = ABlog for Sphinx
+
+[http://engineering.aweber.com/category/python-2/feed/]
+name = AWeber Engineering
+
+[http://www.artima.com/weblogs/feeds/bloggers/aahz.rss]
+name = Aahz
+
+[http://masnun.rocks/tags/python/index.xml]
+name = Abu Ashraf Masnun
+
+[http://techarttiki.blogspot.com/feeds/posts/default/-/python]
+name = Adam Pletcher
+
+[http://adrian.org.ar/tag/python/feed/atom/]
+name = Adrián Deccico
 
 [http://agendaless.com/blog/index.atom?category=python]
 name = Agendaless Consulting
 
-[http://agiletesting.blogspot.com/feeds/posts/default/-/python]
-name = Grig Gheorghiu
+[http://alstatr.blogspot.com/feeds/posts/default/-/Python]
+name = Al-Ahmadgaid Asaad
 
-[http://akaptur.github.io/blog/categories/python/atom.xml]
-name = Allison Kaptur
+[http://marduk.ghost.io/tag/python/rss/]
+name = Albert Hopkins
 
 [http://alecmunro.blogspot.com/feeds/posts/default/-/python]
 name = Alec Munro
+
+[http://blog.aclark.net/blog/category/python/atom.xml]
+name = Alex Clark
 
 [http://alexgaynor.net/feeds/tags/python/]
 name = Alex Gaynor
@@ -57,101 +69,35 @@ name = Alex Gaynor
 [http://alextechrants.blogspot.com/feeds/posts/default/-/python]
 name = Alex Grönholm
 
-[http://allanderek.github.io/categories/python.xml]
-name = Coding Diet
+[https://alexmorozov.github.io/feeds/tag-python.atom.xml]
+name = Alex Morozov
 
-[http://alstatr.blogspot.com/feeds/posts/default/-/Python]
-name = Al-Ahmadgaid Asaad
-
-[http://amjith.blogspot.com/feeds/posts/default/-/python]
-name = Amjith Ramanujam
-
-[http://andy.terrel.us/feeds/python-tag.rss.xml]
-name = Andy R. Terrel
-
-[http://annaraven.blogspot.com/feeds/posts/default/-/python]
-name = Anna Martelli Ravenscroft
-
-[http://anonbadger.wordpress.com/tag/python/feed/atom/]
-name = Toshio Kuratomi
-
-[http://apipes.blogspot.com/feeds/posts/default/-/python]
-name = Tim Lesher
-
-[http://arnavk.com/tags/python/index.xml]
-name = Arnav Khare
-
-[http://aroberge.blogspot.com/atom.xml]
-name = Andre Roberge
-
-[http://artificialcode.blogspot.com/feeds/posts/default/-/python]
-name = Noah Gift
-
-[http://as.ynchrono.us/feeds/posts/default/-/python]
-name = Jean-Paul Calderone
-
-[http://astrocodeschool.com/feeds/all.rss.xml]
-name = Astro Code School
-
-[http://automatingosint.com/blog/category/python/feed/]
-name = Automating OSINT
-
-[http://avelino.xxx/python-en/feed]
-name = Thiago Avelino
-
-[http://baijum.blogspot.com/feeds/posts/default/-/python]
-name = Baiju Muthukadan
-
-[http://ballingt.com/feed.python.xml]
-name = "Thomas Ballinger's Blog"
-
-[http://bangalore.python.org.in/feed.xml]
-name = BangPypers
-
-[http://base-art.net/Articles/rss.xml]
-name = Philippe Normand
-
-[http://be.groovie.org/tagged/python/rss]
-name = Ben Bangert
-
-[http://beauty-of-imagination.blogspot.fr/feeds/posts/default/-/python]
-name = Julien Tayon
-
-[http://beckerfuffle.com/blog/categories/python/atom.xml]
-name = Michael Becker
-
-[http://better-inter.net/rss/python/]
-name = Torsten Engelbrecht
-
-[http://billmill.org/Rss/keyword/python]
-name = Bill Mill
-
-[http://bitofcheese.blogspot.com/feeds/posts/default]
-name = Bit of Cheese
-
-[http://bitshaq.com/tag/python/feed/atom/]
-name = Salman Haq
-
-[http://blaag.haard.se/python.xml]
-name = "Fredrik Håård's Blaag"
-
-[http://blag.whit537.org/feeds/posts/default/-/python]
-name = Chad Whitacre
+[http://feeds.limi.net/on-python]
+name = Alexander Limi
 
 [http://blog.abourget.net/categories/python/feed.atom]
 name = Alexandre Bourget
 
-[http://blog.aclark.net/blog/category/python/atom.xml]
-name = Alex Clark
+[http://www.alexconrad.org/feeds/posts/default/-/python]
+name = Alexandre Conrad
 
-[http://blog.aicookbook.com/category/python/feed/atom/]
-name = The Artificial Intelligence Cookbook
+[http://peadrop.com/blog/category/python/feed/]
+name = Alexandre Vassalotti
 
-[http://blog.alienretro.com/category/python-en-2/feed/]
-name = Nicholas Amorim
+[http://feeds.feedburner.com/en_lexevorg]
+name = Alexey Evseev
+
+[http://un-pythonic.appspot.com/feeds/atom.xml]
+name = Ali Afshar
+
+[http://akaptur.github.io/blog/categories/python/atom.xml]
+name = Allison Kaptur
 
 [http://blog.amir.rachum.com/tagged/python/rss]
 name = Amir Rachum
+
+[http://echorand.me/feeds/python.atom.xml]
+name = Amit Saha
 
 [http://blog.amjith.com/posts.atom?tag=python]
 name = Amjith Ramanujam
@@ -159,242 +105,155 @@ name = Amjith Ramanujam
 [http://blog.amvtek.com/feeds/tags/python.atom.xml]
 name = AmvTek
 
-[http://blog.behnel.de/index.php?feed=rss2&cat=22]
-name = Stefan Behnel
+[https://anarc.at/tag/python-planet/index.rss]
+name = Anarcat
 
-[http://blog.bottlepy.org/feeds/all.atom.xml]
-name = bottlepy-dev
+[http://pyswarm.blogspot.com/feeds/posts/default]
+name = Anastasios Hatzis
 
-[http://blog.briancurtin.com/categories/python.xml]
-name = Brian Curtin
+[http://techtonik.rainforce.org/feeds/posts/default/-/python]
+name = Anatoly Techtonik
 
-[http://blog.cakebread.info/feeds/posts/default/-/python]
-name = Rob Cakebread
+[http://aroberge.blogspot.com/atom.xml]
+name = Andre Roberge
 
-[http://blog.cdleary.com/category/programming/python/feed/]
-name = Chris Leary
+[http://www.andreagrandi.it/category/python/feed/]
+name = Andrea Grandi
 
-[http://blog.chrisarndt.de/category/computer/coding/python/feed]
-name = Chris Arndt
+[http://dalkescientific.com/writings/diary/diary-rss.xml]
+name = Andrew Dalke
 
-[http://blog.delaguardia.com.mx/feed.atom]
-name = Carlos de la Guardia
+[http://drozdyuk.blogspot.com/feeds/posts/default/-/python]
+name = Andriy Drozdyuk
 
-[http://blog.devork.be/feeds/posts/default/-/python]
-name = Floris Bruynooghe
+[http://mindref.blogspot.com/feeds/posts/default/-/python]
+name = Andriy Kornatskyy
 
-[http://blog.dowski.com/category/python/feed]
-name = The Occasional Occurrence
+[http://kendriu.com/feeds/python.atom.xml]
+name = Andrzej Skupień
 
-[http://blog.dscpl.com.au/feeds/posts/default]
-name = Graham Dumpleton
+[http://mysql-python.blogspot.com/feeds/posts/default]
+name = Andy Dustman
 
-[http://blog.efford.org/tag/feeds/python.atom.xml]
-name = Nick Efford
+[http://andy.terrel.us/feeds/python-tag.rss.xml]
+name = Andy R. Terrel
 
-[http://blog.endpoint.com/feeds/posts/default/-/python]
-name = End Point
+[http://halfcooked.com/blog/feed/]
+name = Andy Todd
 
-[http://blog.enthought.com/?feed=rss2]
-name = Enthought
+[https://nerandell.github.io/atom.xml]
+name = Ankit Chandawala
 
-[http://blog.europython.eu/rss]
-name = EuroPython
+[http://annaraven.blogspot.com/feeds/posts/default/-/python]
+name = Anna Martelli Ravenscroft
 
-[http://blog.extracheese.org/feeds/posts/default/-/python]
-name = Gary Bernhardt
+[http://codingweasel.blogspot.com/feeds/posts/default/-/python]
+name = Anthony Baxter
 
-[http://blog.filipesaraiva.info/?feed=rss2&tag=planet-python]
-name = Filipe Saraiva
+[http://kpoxit.blogspot.com/feeds/posts/default/-/python]
+name = Anton Belyaev
 
-[http://blog.fizyk.net.pl/tags/python.xml]
-name = Grzegorz Śliwiński
+[http://bobrochel.blogspot.com/feeds/posts/default/-/python]
+name = Anton Bobrov
 
-[http://blog.flaper87.com/feeds/python.atom.xml]
-name = Flavio Percoco
+[https://anweshadas.in/tag/python/rss/]
+name = Anwesha Das
 
-[http://blog.garage-coding.com/tag/python/feed.xml]
-name = Stefan Petrea
+[http://www.appneta.com/blog/tag/python-applications/feed/]
+name = AppNeta Blog
 
-[http://blog.gmludo.eu/feeds/posts/default/-/python]
-name = Ludovic Gasc
+[http://lucumr.pocoo.org/feed.atom]
+name = Armin Ronacher
 
-[http://blog.gocept.com/tag/python/feed/atom/]
-name = Gocept Weblog
+[http://arnavk.com/tags/python/index.xml]
+name = Arnav Khare
 
-[http://blog.godson.in/feeds/posts/default/-/Python]
-name = Godson Gera
+[http://feeds.feedburner.com/PythonMyThoughtsLearnings]
+name = Ashish Dutt
 
-[http://blog.hannosch.eu/feeds/posts/default/-/python?alt=rss]
-name = Hanno Schlichting
+[http://pyfunc.blogspot.com/feeds/posts/default/-/python]
+name = Ashish Vidyarthi
 
-[http://blog.ianbicking.org/category/python/feed/atom/]
-name = Ian Bicking
+[http://xthought.org/feeds/latest/category/python/]
+name = Ashley Camba
 
-[http://blog.irukado.org/category/python/feed/]
-name = Lee Braiden
+[http://astrocodeschool.com/feeds/all.rss.xml]
+name = Astro Code School
 
-[http://blog.isotoma.com/atom.xml]
-name = Isotoma
+[http://www.toolness.com/wp/?cat=11&feed=rss2]
+name = Atul Varma -- Toolness
 
-[http://blog.jarrodmillman.com/feeds/posts/default/-/python]
-name = Jarrod Millman
+[http://www.codemakesmehappy.com/feeds/posts/default/-/Python]
+name = Audrey Roy Greenfeld
 
-[http://blog.jorgenschaefer.de/feeds/posts/default/-/Python]
-name = Jorgen Schäfer
+[http://automatingosint.com/blog/category/python/feed/]
+name = Automating OSINT
 
-[http://blog.klymyshyn.com/feeds/posts/default/-/python]
-name = Max Klymyshyn
+[http://baijum.blogspot.com/feeds/posts/default/-/python]
+name = Baiju Muthukadan
 
-[http://blog.kollerie.com/feeds/Python.atom.xml]
-name = Guido Kollerie
+[http://gbtami.github.io/feed.python.xml]
+name = Bajusz Tamás
 
-[http://blog.kritigodey.com/tag/python/rss]
-name = Kriti Godey
+[http://importthis.tumblr.com/tagged/python/rss]
+name = Balthazar Rouberol
 
-[http://blog.labix.org/tag/python/feed]
-name = Gustavo Niemeyer
+[http://bangalore.python.org.in/feed.xml]
+name = BangPypers
 
-[http://blog.lerner.co.il/category/python/feed/]
-name = Reuven Lerner
+[http://www.djangrrl.com/feeds/python/]
+name = Barbara Shaurette
 
-[http://blog.lintel.in/tag/python/feed/]
-name = Lintel Technologies
+[http://www.wefearchange.org/feeds/posts/default]
+name = Barry Warsaw
 
-[http://blog.lost-theory.org/tags/python/feed.atom]
-name = Steven Kryskalla
+[http://www.bedjango.com/planet/feed/]
+name = BeDjango
 
-[http://blog.ludovf.net/feed/python/atom/]
-name = Ludovico Fischer
+[http://be.groovie.org/tagged/python/rss]
+name = Ben Bangert
 
-[http://blog.madpython.com/tag/python/feed/atom/]
-name = Xavier Spriet
+[http://codedstructure.blogspot.com/feeds/posts/default/-/python]
+name = Ben Bass
 
-[http://blog.mdomans.com/rss/python/]
-name = Michał Domański
+[http://clusterbleep.net/blog/category/python/feed/]
+name = Ben Rousch
 
-[http://blog.melhase.net/xml/rss20/feed.xml]
-name = Troy Melhase
+[http://mrben.co.uk/feed/python/]
+name = Ben Tappin
 
-[http://blog.minchin.ca/feeds/label.python.atom.xml]
-name = William Minchin
+[http://pybites.blogspot.com/feeds/posts/default]
+name = Benjamin Peterson
 
-[http://blog.mozilla.com/webdev/category/python-2/feed/]
-name = Mozilla Web Development
+[http://just-another.net/feeds/tag/python/]
+name = Benjamin W. Smith
 
-[http://blog.nonsequitarian.org/feeds/tags/planetpython/]
-name = Rob Miller
+[http://www.benjiyork.com/blog/atom.xml]
+name = Benji York
 
-[http://blog.parcon.opengroove.org/feeds/posts/default]
-name = The Parcon Blog
+[http://zebert.blogspot.com/feeds/posts/default/-/python]
+name = Bertrand Mathieu
 
-[http://blog.partecs.com/category/python/feed]
-name = Partecs
+[http://feeds.feedburner.com/thetaranights]
+name = Bhishan Bhandari
 
-[http://blog.patx.me/rss]
-name = Harrison Erd
+[http://billmill.org/Rss/keyword/python]
+name = Bill Mill
 
-[http://blog.picante.co.nz/latest/feed/]
-name = Gene Campbell
+[http://news.open-bio.org/news/category/obf-projects/biopython/feed/atom/]
+name = BioPython News
 
-[http://blog.pyamf.org/feed]
-name = PyAMF Blog
+[http://bitofcheese.blogspot.com/feeds/posts/default]
+name = Bit of Cheese
 
-[http://blog.pycarolinas.org/rss/]
-name = PyCarolinas
+[http://tillenius.me/feeds/atom/tag/python/]
+name = Björn Tillenius
 
-[http://blog.pyspoken.com/feed/atom/]
-name = Philip Semanchuk
+[http://www.blendedtechnologies.com/category/python/rss/]
+name = Blended Technologies
 
-[http://blog.python-eve.org/feeds/rss.xml]
-name = Eve REST Framework
-
-[http://blog.pythonanywhere.com/feed/]
-name = Python Anywhere
-
-[http://blog.qutebrowser.org/feeds/tag-pyplanet.rss.xml]
-name = qutebrowser development blog
-
-[http://blog.randell.ph/tag/python/feed/atom/]
-name = Randell Benavidez
-
-[http://blog.rtwilson.com/category/programming-2/python/feed/]
-name = Robin Wilson
-
-[http://blog.sandbox.lt/tag/rss/en/python]
-name = Dalius Dobravolskas
-
-[http://blog.serverdensity.com/category/python/feed/]
-name = Server Density
-
-[http://blog.sramana.in/rss.xml?tag=python]
-name = Ramana
-
-[http://blog.startifact.com/categories/planetpython.xml]
-name = Martijn Faassen
-
-[http://blog.stxnext.com/feeds/python.atom.xml]
-name = STX Next
-
-[http://blog.superadditive.com/category/python/feed]
-name = Juan Rivas
-
-[http://blog.tedmiston.com/tag/python/rss]
-name = Taylor Edmiston
-
-[http://blog.teemu.im/tags/python/feed/]
-name = Teemu Harju
-
-[http://blog.the-moon.net/feeds/posts/default/-/python]
-name = Richard Wall
-
-[http://blog.thedigitalcatonline.com/categories/python/atom.xml]
-name = The Digital Cat
-
-[http://blog.tplus1.com/index.php/category/python/feed]
-name = Matthew Wilson
-
-[http://blog.tshirtman.fr/tags/python/feed.atom]
-name = Gabriel Pettier
-
-[http://blog.vmfarms.com/feeds/posts/default/-/python]
-name = Hany Fahim
-
-[http://blog.vrplumber.com/index.php?/feeds/categories/1-Snaking.rss]
-name = Mike C. Fletcher
-
-[http://blog.wraithan.net/tag/python/feed/]
-name = Wraithan
-
-[http://blog.wyattbaldwin.com/feed/planet-python/atom.xml]
-name = Wyatt Baldwin
-
-[http://blog.zacharyvoase.com/tagged/python/rss]
-name = Zachary Voase
-
-[http://blog.ziade.org/tag/python/feed]
-name = Tarek Ziade
-
-[http://blog.zsoldosp.eu/category/python/feed/]
-name = Péter Zsoldos
-
-[http://blogfeed.zato.io/blog/categories/planet-python.xml]
-name = Zato Blog
-
-[http://blogologue.com/atom.xml?category=1470141490X3]
-name = "Morphex's Blogologue"
-
-[http://blogs.fluidinfo.com/terry/category/python/feed/atom/]
-name = Terry Jones
-
-[http://blogs.gnome.org/johan/category/python/feed/atom]
-name = Johan Dahlin
-
-[http://blogs.gnome.org/markmc/category/python/feed/]
-name = Mark McLoughlin
-
-[http://blogs.law.harvard.edu/ivan/xml/rss.xml]
-name = Ivan Krstic
+[https://tech.blue-yonder.com/tag/python/feed/]
+name = Blue Yonder Tech
 
 [http://bluebream.posterous.com/rss.xml]
 name = BlueBream
@@ -402,86 +261,173 @@ name = BlueBream
 [http://bluedynamics.com/pythonrelated/++feed++/@@rss.xml]
 name = BlueDynamics Alliance
 
-[http://bluesock.org/~willkg/blog/tag/python.xml]
-name = Will Kahn-Greene
+[http://source.mihelac.org/feeds/categories/django/]
+name = Bojan Mihelac
 
-[http://bobrochel.blogspot.com/feeds/posts/default/-/python]
-name = Anton Bobrov
+[http://rhodesmill.org/brandon/category/python/feed]
+name = Brandon Rhodes
+
+[http://python4dads.wordpress.com/feed/]
+name = Brendan Scott
+
+[https://snarky.ca/rss/]
+name = Brett Cannon
+
+[http://blog.briancurtin.com/categories/python.xml]
+name = Brian Curtin
+
+[http://ferringb.wordpress.com/category/python/feed/atom/]
+name = Brian Harring
+
+[http://www.protocolostomy.com/category/technology/python/feed]
+name = Brian Jones
+
+[http://pythontesting.net/on/planet/feed]
+name = Brian Okken
+
+[http://nicoddemus.github.io/tag/python/atom.xml]
+name = Bruno Oliveira
 
 [http://brunorocha.org/tag/pythonplanet.atom]
 name = Bruno Rocha
 
-[http://bsg.lericson.se/rssfiltered.rss]
-name = Ludvig Ericson
+[http://scrollingtext.org/taxonomy/term/29/0/feed]
+name = Bryce Verdier
 
-[http://buchuki.com/index.php/feed/]
-name = Dusty Phillips
+[http://www.caktusgroup.com/feeds/tags/python/]
+name = Caktus Consulting Group
+
+[http://www.calvinx.com/category/code/python/feed/]
+name = Calvin Cheng
+
+[http://techblog.ironfroggy.com/feeds/posts/default/-/programming]
+name = Calvin Spealman
+
+[http://thelivingpearl.com/tag/python/feed/]
+name = "Captain DeadBones'' Chronicles"
 
 [http://carlchenet.com/category/planetpython/feed/]
 name = Carl Chenet
 
+[http://pyright.blogspot.com/feeds/posts/default?alt=rss]
+name = Carl Trachte
+
+[http://themindcaster.blogspot.com/feeds/posts/default/-/python]
+name = Carlos Eduardo de Paula
+
+[http://blog.delaguardia.com.mx/feed.atom]
+name = Carlos de la Guardia
+
+[http://eatthedots.blogspot.com/feeds/posts/default]
+name = Casey Duncan
+
+[http://python-catalin.blogspot.com/feeds/posts/default/-/python]
+name = Catalin George Festila
+
 [http://catherinedevlin.blogspot.com/feeds/posts/default/-/python]
 name = Catherine Devlin
 
-[http://chaos.caltech.edu/cgi-bin/diane-planetpython-feed.py]
-name = Diane Trout
+[http://www.super-cooper.com/archive/category/python/feed]
+name = Chad Cooper
 
-[http://charlesnagy.info/category/it/python/feed/]
-name = Károly Nagy
+[http://blag.whit537.org/feeds/posts/default/-/python]
+name = Chad Whitacre
 
-[http://chidjango.dev.imagescape.com/blog/feeds/rss/]
-name = Imaginary Landscape
+[http://www.checkandshare.com/blog/?cat=2?&feed=rss2]
+name = Checking and Sharing
+
+[http://blog.chrisarndt.de/category/computer/coding/python/feed]
+name = Chris Arndt
+
+[http://metachris.org/category/python/feed/atom/]
+name = Chris Hager
+
+[http://blog.cdleary.com/category/programming/python/feed/]
+name = Chris Leary
+
+[http://weblog.lonelylion.com/category/python/feed]
+name = Chris McAvoy
+
+[http://plope.com/python.rss]
+name = Chris McDonough
 
 [http://chris-miles-writes-python.blogspot.com/feeds/posts/default?alt=rss]
 name = Chris Miles
 
-[http://climateecology.wordpress.com/tag/python/feed/]
-name = Nathan Lemoine
+[http://www.unquietdesperation.com/category/python/feed]
+name = Chris Miller
 
-[http://clouddbs.blogspot.com/feeds/posts/default/-/python]
-name = John Burns
+[http://pyinformatics.blogspot.com/feeds/posts/default]
+name = Chris Mitchell
+
+[http://pbpython.com/feeds/all.atom.xml]
+name = Chris Moffitt
+
+[http://percious.com/blog/feed]
+name = Chris Perkins
+
+[http://ideas.offby1.net/feeds/tag-python.atom.xml]
+name = Chris Rose
+
+[http://feeds.feedburner.com/ChrisWarrickPython]
+name = Chris Warrick
+
+[http://www.chrisbarra.me/tags/python.xml]
+name = Christian Barra
+
+[http://lipyrary.blogspot.com/feeds/posts/default]
+name = Christian Heimes
+
+[http://www.technobabble.dk/feeds/tags/python/]
+name = Christian Joergensen
+
+[http://feeds.feedburner.com/mrtopf-python]
+name = Christian Scholz
+
+[https://cito.github.io/tags/python/index.xml]
+name = Christoph Zwerschke
+
+[http://the-space-station.com/tags/planet-python/feed.atom]
+name = Christopher Denter
+
+[http://www.cmlenz.net/blog/python.xml]
+name = Christopher Lenz
+
+[http://www.percious.com/blog/?feed=rss2&cat=3]
+name = Christopher Perkins
+
+[http://www.evilchuck.com/feeds/posts/default/-/python]
+name = Chuck Thier
+
+[http://www.redmountainsw.com/wordpress/archives/category/python/feed/atom]
+name = Chui Tey
+
+[http://csparpa.github.io/blog/feeds/python.atom.xml]
+name = Claudio Sparpaglione
 
 [http://cloudnumbers.com/category/python/feed/atom]
 name = Cloudnumbers
 
-[http://clusterbleep.net/blog/category/python/feed/]
-name = Ben Rousch
+[https://clusterhq.com/feed.python.xml]
+name = ClusterHQ
 
-[http://codebright.wordpress.com/category/python/feed/atom/]
-name = Paul Redman
-
-[http://codedstructure.blogspot.com/feeds/posts/default/-/python]
-name = Ben Bass
-
-[http://codeinthehole.com/writing/tagged/python/feed/]
-name = David Winterbottom
+[https://cobe.io/blog/categories/python.xml]
+name = Cobe.io
 
 [http://codesnipers.com/?q=taxonomy/term/16/0/feed]
 name = CodeSnipers
 
-[http://codewithoutrules.com/python-atom.xml]
-name = Itamar Turner Trauring
+[https://www.codementor.io/python/tutorial/feed/]
+name = Codementor
 
-[http://codingandlinux.blogspot.com/feeds/posts/default/-/python]
-name = Luca Botti
+[http://allanderek.github.io/categories/python.xml]
+name = Coding Diet
 
-[http://codingweasel.blogspot.com/feeds/posts/default/-/python]
-name = Anthony Baxter
-
-[http://commandline.org.uk/feeds/full/python/]
-name = Zeth
-
-[http://compiletoi.net/feeds/python.atom.xml]
-name = Georges Dubus
-
-[http://compoundthinking.com/blog/index.php/category/python/feed]
-name = Mark Ramm
+[http://oakwinter.com/code/category/python/feed/rss]
+name = Collin Winter
 
 [http://concretecloud.github.io/feeds/python.atom.xml]
 name = Concrete Clouds
-
-[http://continuum.io/blog/category/python/feed]
-name = Continuum Blog
 
 [http://continuum.io/blog/feed]
 name = Continuum Analytics Blog
@@ -489,113 +435,188 @@ name = Continuum Analytics Blog
 [http://continuum.io/press/feed]
 name = Continuum Analytics News
 
+[http://continuum.io/blog/category/python/feed]
+name = Continuum Blog
+
 [http://controlfd.com/feed.python.xml]
 name = "Control F'd"
 
-[http://copia.posterous.com/rss.xml?tag=python]
-name = Uche Ogbuji
+[http://www.coresoftwaregroup.com/blog/topics/python/@@rss.xml]
+name = Core Software
 
-[http://copypasteprogrammer.blogspot.com/feeds/posts/default/-/python]
-name = Mattias Brändström
-
-[http://cosmicpercolator.com/category/python/feed/atom/]
-name = Kristján Valur Jónsson
-
-[http://craigkerstiens.com/categories/python/atom.xml]
-name = Craig Kerstiens
-
-[http://csparpa.github.io/blog/feeds/python.atom.xml]
-name = Claudio Sparpaglione
-
-[http://dabeaz.blogspot.com/feeds/posts/default]
-name = Dave Beazley
-
-[http://dailytechvideo.com/category/python/feed/]
-name = Daily Tech Video (Python)
-
-[http://dalkescientific.com/writings/diary/diary-rss.xml]
-name = Andrew Dalke
-
-[http://damyanon.net/tag/python/feed/]
-name = Damyan Bogoev
-
-[http://danielnouri.org/notes/category/python/feed/index.xml]
-name = Daniel Nouri
-
-[http://datacommunitydc.org/blog/tag/python/feed/]
-name = Data Community DC
-
-[http://davebehnke.com/feeds/python.atom.xml]
-name = Dave Behnke
-
-[http://davidemoro.blogspot.com/feeds/posts/default/-/planetpython]
-name = Davide Moro
-
-[http://davywybiral.blogspot.com/feeds/posts/default]
-name = Davy Wybiral
-
-[http://dbader.org/blog/tags/python/rss]
-name = Daniel Bader
-
-[http://defrobnication.blogspot.com/feeds/posts/default/-/python]
-name = Grant Baillie
-
-[http://degizmo.com/feed/]
-name = DeGizmo
+[http://feeds.feedburner.com/goldblog/python]
+name = Corey Goldberg
 
 [http://depressedoptimism.com/?tag=python&format=rss]
 name = Corey Oordt
 
-[http://derrickpetzold.com/index.php/tag/python/feed/atom/]
-name = Derrick Petzold
+[http://feeds.feedburner.com/cormoran-project]
+name = Cormoran Project
 
-[http://dev-tricks.net/category/code/python/feed]
-name = Julien Palard
+[http://craigkerstiens.com/categories/python/atom.xml]
+name = Craig Kerstiens
 
-[http://dev.2degreesnetwork.com/feeds/posts/default/-/python]
-name = 2degrees
+[http://labs.creativecommons.org/category/python/feed/]
+name = Creative Commons
 
-[http://dev.timparkin.co.uk/feeds/posts/default?alt=rss]
-name = Tim Parkin
+[http://feeds2.feedburner.com/portablecommandline]
+name = Cross-Platform Command Line Tools
 
-[http://devalien.com/rss.php?module=blog&cat=python]
-name = Gonçalo Margalho
+[http://feeds.feedburner.com/cubicweborg]
+name = CubicWeb
 
-[http://devblog.4teamwork.ch/blog/categories/planet-python/atom.xml]
-name = 4teamwork
+[https://ntguardian.wordpress.com/category/python/feed/]
+name = Curtis Miller
 
-[http://developerblog.myo.com/tag/python/rss/]
-name = Python with Myo
+[http://dspillustrations.com/static/dspillustrations.rss.xml]
+name = DSPIllustrations.com
+
+[http://dailytechvideo.com/category/python/feed/]
+name = Daily Tech Video (Python)
+
+[http://blog.sandbox.lt/tag/rss/en/python]
+name = Dalius Dobravolskas
 
 [http://dfwpython.blogspot.com/feeds/posts/default]
 name = Dallas Fort Worth Pythoneers
 
-[http://diefenba.ch/rss/blog?tags=python]
-name = Kai Diefenbach
+[http://www.damian.oquanta.info/categories/python.xml]
+name = Damián Avila
 
-[http://dietbuddha.blogspot.com/feeds/posts/default/-/python]
-name = William Thompson
+[http://damyanon.net/tag/python/feed/]
+name = Damyan Bogoev
 
-[http://django.zone/blog/posts/rss/]
-name = Django Zone
+[http://late.am/python.feed.xml]
+name = Dan Crosta
 
-[http://djangostars.com/blog/category/python/rss/]
-name = Djangostars
+[http://strombrg.blogspot.com/feeds/posts/default/-/Python]
+name = Dan Stromberg
 
-[http://djangoweekly.com/blog/feed/]
-name = Django Weekly
+[http://dbader.org/blog/tags/python/rss]
+name = Daniel Bader
+
+[http://www.endlesslycurious.com/tag/python/feed/]
+name = Daniel Brown
+
+[http://danielnouri.org/notes/category/python/feed/index.xml]
+name = Daniel Nouri
+
+[https://www.pydanny.com/feeds/python.atom.xml]
+name = Daniel Roy Greenfeld
+
+[http://www.gefira.pl/blog/tag/planet-python/feed/]
+name = Dariusz Suchojad
+
+[http://datacommunitydc.org/blog/tag/python/feed/]
+name = Data Community DC
+
+[http://www.dataschool.io/tag/python/rss/]
+name = Data School
+
+[https://www.datacamp.com/community/blog/python-feed.rss]
+name = DataCamp
+
+[https://www.dataquest.io/blog/tag/python/index.xml]
+name = Dataquest
+
+[http://dabeaz.blogspot.com/feeds/posts/default]
+name = Dave Beazley
+
+[http://davebehnke.com/feeds/python.atom.xml]
+name = Dave Behnke
+
+[http://hwit.org/feeds/python.atom.xml]
+name = Dave Haynes
+
+[http://www.artima.com/weblogs/feeds/bloggers/goodger.rss]
+name = David Goodger
+
+[http://www.davidgrant.ca/taxonomy/term/14/0/feed]
+name = David Grant
+
+[http://www.djcinnovations.com/archives/category/python/feed/atom]
+name = David J C Beach
+
+[http://thppython.blogspot.com/feeds/posts/default]
+name = David Janes
+
+[http://www.drmaciver.com/category/python/feed/]
+name = David MacIver
 
 [http://dmalcolm.livejournal.com/data/atom?tag=python]
 name = David Malcolm
 
-[http://dmoonc.com/blog/?cat=24&feed=rss2]
-name = Mitch Chapman
+[http://www.redesigndavid.com/atom?&tags=python]
+name = David Marte
+
+[http://www.traceback.org/category/python/feed]
+name = David Stanek
+
+[http://www.szotten.com/david/feeds/python.atom.xml]
+name = David Szotten
+
+[http://codeinthehole.com/writing/tagged/python/feed/]
+name = David Winterbottom
+
+[http://davidemoro.blogspot.com/feeds/posts/default/-/planetpython]
+name = Davide Moro
+
+[http://feeds2.feedburner.com/Daftpython]
+name = Davy Mitchell
+
+[http://davywybiral.blogspot.com/feeds/posts/default]
+name = Davy Wybiral
+
+[http://www.luckydonkey.com/category/python/rss]
+name = Dazza
+
+[http://degizmo.com/feed/]
+name = DeGizmo
+
+[http://makkalot-opensource.blogspot.com/feeds/posts/default/-/python]
+name = Denis Kurov
+
+[http://derrickpetzold.com/index.php/tag/python/feed/atom/]
+name = Derrick Petzold
+
+[http://livingcode.org/tag/python.atom]
+name = Dethe Elza
+
+[http://chaos.caltech.edu/cgi-bin/diane-planetpython-feed.py]
+name = Diane Trout
+
+[http://www.diego-garcia.info/python.atom.xml]
+name = Diego Garcia
+
+[http://www.djangoproject.com/rss/weblog/]
+name = Django Weblog
+
+[http://djangoweekly.com/blog/feed/]
+name = Django Weekly
+
+[http://django.zone/blog/posts/rss/]
+name = Django Zone
+
+[http://www.djangocon.org/blog/feeds/rss/latest/]
+name = Djangocon
+
+[http://www.djangofoo.com/feed]
+name = Djangofeed
+
+[http://djangostars.com/blog/category/python/rss/]
+name = Djangostars
 
 [http://doingmathwithpython.github.io/feeds/all.atom.xml]
 name = Doing Math with Python
 
+[http://feeds.doughellmann.com/doughellmann/python]
+name = Doug Hellmann
+
 [http://douglatornell.ca/blog/category/python/feed/index.xml]
 name = Doug Latornell
+
+[http://www.dougalmatthews.com/feeds/python.atom.xml]
+name = Dougal Matthews
 
 [http://dougma.com/category/python/feed/]
 name = Douglas Napoleone
@@ -603,245 +624,152 @@ name = Douglas Napoleone
 [http://dreamhost.com/dreamscape/tag/python/feed/]
 name = DreamHost
 
-[http://drozdyuk.blogspot.com/feeds/posts/default/-/python]
-name = Andriy Drozdyuk
+[http://oubiwann.blogspot.com/feeds/posts/default/-/python]
+name = Duncan McGreggor
 
-[http://dspillustrations.com/static/dspillustrations.rss.xml]
-name = DSPIllustrations.com
-
-[http://dunderboss.blogspot.com/feeds/posts/default/-/python]
-name = Philip Jenvey
+[http://buchuki.com/index.php/feed/]
+name = Dusty Phillips
 
 [http://easygui.wordpress.com/feed/atom/]
 name = EasyGUI
 
-[http://eatthedots.blogspot.com/feeds/posts/default]
-name = Casey Duncan
-
-[http://echorand.me/feeds/python.atom.xml]
-name = Amit Saha
-
 [http://edcrewe.blogspot.com/feeds/posts/default/-/python]
 name = Ed Crewe
-
-[http://edreamleo.blogspot.com/feeds/posts/default/-/python]
-name = Edward K. Ream
-
-[http://eigenhombre.com/feed.python.xml]
-name = John Jacobsen
-
-[http://eli.thegreenplace.net/feeds/python.atom.xml]
-name = Eli Bendersky
-
-[http://en.ig.ma/notebook/feeds/atom/tag/python.xml]
-name = Filip Wasilewski
-
-[http://engineering.aweber.com/category/python-2/feed/]
-name = AWeber Engineering
-
-[http://eniramltd.github.io/devblog/rss/categories/python.xml]
-name = Eniram Ltd.
-
-[http://entitycrisis.blogspot.com/feeds/posts/default/-/Python]
-name = Simon Wittber
-
-[http://ericholscher.com/blog/archive/tag/python/atom.xml]
-name = Eric Holscher
-
-[http://etienned.github.io/categories/python.xml]
-name = Etienne Desautels
-
-[http://evennia.blogspot.com/feeds/posts/default]
-name = Evennia
-
-[http://eventh.tumblr.com/tagged/Python/rss]
-name = Even Wiik Thomassen
-
-[http://farmdev.com/feeds/thoughts/on/3/python/]
-name = Kumar McMillan
-
-[http://feeding.cloud.geek.nz/tags/python/index.rss]
-name = François Marier
-
-[http://feeds.doughellmann.com/doughellmann/python]
-name = Doug Hellmann
-
-[http://feeds.feedburner.com/ChrisWarrickPython]
-name = Chris Warrick
-
-[http://feeds.feedburner.com/FromPythonImportPodcast]
-name = From Python Import Podcast
-
-[http://feeds.feedburner.com/GoDeh]
-name = Go Deh
-
-[http://feeds.feedburner.com/JoePitz-TechnologyBlogPython]
-name = Joe Pitz
-
-[http://feeds.feedburner.com/JonathansPythonBlog]
-name = Jonathan Harrington
-
-[http://feeds.feedburner.com/LateralOpinionpython]
-name = Roberto Alsina
-
-[http://feeds.feedburner.com/PyCon]
-name = PyCon
-
-[http://feeds.feedburner.com/Pycharm]
-name = PyCharm
-
-[http://feeds.feedburner.com/PythonInsider]
-name = Python Insider
-
-[http://feeds.feedburner.com/PythonMyThoughtsLearnings]
-name = Ashish Dutt
-
-[http://feeds.feedburner.com/RamRachumsBlog/planetpython]
-name = Ram Rachum
 
 [http://feeds.feedburner.com/RoadWarriorCollaborationPython]
 name = Ed Taekema
 
-[http://feeds.feedburner.com/StreamHackerPython]
-name = Jacob Perkins
+[http://edreamleo.blogspot.com/feeds/posts/default/-/python]
+name = Edward K. Ream
 
-[http://feeds.feedburner.com/TwistedMatrixLaboratories]
-name = Twisted Matrix Labs
+[http://pythonthusiast.pythonblogs.com/230_pythonthusiast/feeds/rss20]
+name = Eko S. Wibowo
 
-[http://feeds.feedburner.com/WebInfrastructureSystemsDeploymentsAndTechnologiesPython]
-name = Jeff McNeil
+[http://eli.thegreenplace.net/feeds/python.atom.xml]
+name = Eli Bendersky
 
-[http://feeds.feedburner.com/btbytes_python]
-name = Pradeep Gowda
+[http://touilleman.xyz/blog/category/python/feed/index.xml]
+name = Emmanuel Leblond
 
-[http://feeds.feedburner.com/codeboje_python]
-name = codeboje
+[http://blog.endpoint.com/feeds/posts/default/-/python]
+name = End Point
 
-[http://feeds.feedburner.com/cormoran-project]
-name = Cormoran Project
+[http://eniramltd.github.io/devblog/rss/categories/python.xml]
+name = Eniram Ltd.
 
-[http://feeds.feedburner.com/cubicweborg]
-name = CubicWeb
+[http://blog.enthought.com/?feed=rss2]
+name = Enthought
 
-[http://feeds.feedburner.com/duffyd]
-name = Tim Knapp
+[https://examachine.net/blog/category/python/feed/]
+name = Eray Özkural (examachine)
 
-[http://feeds.feedburner.com/en_lexevorg]
-name = Alexey Evseev
+[http://www.eflorenzano.com/blog/feeds/posts/python/]
+name = Eric Florenzano
 
-[http://feeds.feedburner.com/garyrobinson/python]
-name = Gary Robinson
+[http://ericholscher.com/blog/archive/tag/python/atom.xml]
+name = Eric Holscher
 
-[http://feeds.feedburner.com/getnikola/QBjz]
-name = Nikola
+[http://pythonfilter.com/rss.xml]
+name = "Eric Wu's Pythonfilter"
 
-[http://feeds.feedburner.com/goldblog/python]
-name = Corey Goldberg
+[http://www.marsja.se/category/python/feed/]
+name = Erik Marsja
 
-[http://feeds.feedburner.com/gumuznl]
-name = Guyon Moree
+[http://etienned.github.io/categories/python.xml]
+name = Etienne Desautels
 
-[http://feeds.feedburner.com/logilaborg_en]
-name = Logilab
+[http://blog.europython.eu/rss]
+name = EuroPython
 
-[http://feeds.feedburner.com/mrtopf-python]
-name = Christian Scholz
+[http://www.europython-society.org/rss]
+name = EuroPython Society
 
-[http://feeds.feedburner.com/phoe6pythonfeeds]
-name = Senthil Kumaran
+[http://www.evanfosmark.com/category/programming/python/feed]
+name = Evan Fosmark
 
-[http://feeds.feedburner.com/pje-on-programming]
-name = Phillip J. Eby
+[http://blog.python-eve.org/feeds/rss.xml]
+name = Eve REST Framework
 
-[http://feeds.feedburner.com/pypix]
-name = Pypix
+[http://eventh.tumblr.com/tagged/Python/rss]
+name = Even Wiik Thomassen
 
-[http://feeds.feedburner.com/sfpy]
-name = Salim Fadhley
+[http://evennia.blogspot.com/feeds/posts/default]
+name = Evennia
 
-[http://feeds.feedburner.com/shuttlethread-python]
-name = Laurence Rowe
+[http://interactivepython.org/courselib/feed/everyday.rss]
+name = Everyday Python
 
-[http://feeds.feedburner.com/shutupandship_python]
-name = Praveen Gollakota
+[http://www.snowboardingcoder.com/django/?feed=rss2]
+name = Experienced Django
 
-[http://feeds.feedburner.com/simeon_visser_python]
-name = Simeon Visser
+[http://pydev.blogspot.com/atom.xml]
+name = Fabio Zadrozny
 
-[http://feeds.feedburner.com/thetaranights]
-name = Bhishan Bhandari
+[http://www.majid.info/mylos/weblog/categories/python/rss.xml]
+name = Fazal Majid
 
-[http://feeds.feedburner.com/thobe/wardrobe]
-name = Tobias Ivarsson
+[http://en.ig.ma/notebook/feeds/atom/tag/python.xml]
+name = Filip Wasilewski
 
-[http://feeds.feedburner.com/voidspace]
-name = Michael Foord
+[http://blog.filipesaraiva.info/?feed=rss2&tag=planet-python]
+name = Filipe Saraiva
 
-[http://feeds.feedburner.com/zopatista/python]
-name = Martijn Pieters
+[http://pyinsci.blogspot.com/feeds/posts/default]
+name = Flavio Coelho
 
-[http://feeds.hackercodex.com/feeds/python]
-name = Justin Mayer
+[http://blog.flaper87.com/feeds/python.atom.xml]
+name = Flavio Percoco
 
-[http://feeds.limi.net/on-python]
-name = Alexander Limi
+[http://blog.devork.be/feeds/posts/default/-/python]
+name = Floris Bruynooghe
 
-[http://feeds.wordaligned.org/wordaligned/python]
-name = Thomas Guest
-
-[http://feeds2.feedburner.com/ASongForTheLovers]
-name = Lawrence Oluyede
-
-[http://feeds2.feedburner.com/Daftpython]
-name = Davy Mitchell
-
-[http://feeds2.feedburner.com/portablecommandline]
-name = Cross-Platform Command Line Tools
-
-[http://feetup.org/blog/dev/python?flav=rss]
-name = Jim Hughes
-
-[http://ferringb.wordpress.com/category/python/feed/atom/]
-name = Brian Harring
-
-[http://fiber-space.de/wordpress/category/python/feed]
-name = Kay Schluehr
-
-[http://foolish-assertions.blogspot.com/feeds/posts/default/-/python]
-name = William Reade
-
-[http://freepythontips.wordpress.com/feed/atom]
-name = Yasoob Khalid
-
-[http://freshfoo.com/blog/index.atom]
-name = "Menno's Musings"
-
-[http://fruch.github.io/feed.python.xml]
-name = Israel Fruchter
-
-[http://furius.ca/blog/tag/Python/rss]
-name = Martin Blais
+[http://www.franciscosouza.net/feeds/posts/default/-/python]
+name = Francisco Souza
 
 [http://fwierzbicki.blogspot.com/atom.xml]
 name = Frank Wierzbicki
 
-[http://g.raphaelli.com/tags/python/feed.atom]
-name = Gilad Raphaelli
+[http://raspberry-python.blogspot.com/feeds/posts/default/-/english/python]
+name = François Dion
+
+[http://feeding.cloud.geek.nz/tags/python/index.rss]
+name = François Marier
+
+[http://www.fridh.nl/tag/python.atom.xml]
+name = Frederik Rietdijk
+
+[http://blaag.haard.se/python.xml]
+name = "Fredrik Håård's Blaag"
+
+[http://online.effbot.org/rss.xml]
+name = Fredrik Lundh
+
+[http://feeds.feedburner.com/FromPythonImportPodcast]
+name = From Python Import Podcast
+
+[https://www.fullstackpython.com/feeds/all.atom.xml]
+name = Full Stack Python
 
 [http://gael-varoquaux.info/feeds/programming.atom.xml]
 name = Ga&#235;l Varoquaux
 
-[http://ganwell.github.io/feeds/python.atom.xml]
-name = Jean-Louis Fuchs
+[http://blog.tshirtman.fr/tags/python/feed.atom]
+name = Gabriel Pettier
 
-[http://garbas.si/blog/category/latest-python/RSS]
-name = Rok Garbas
+[http://www.galvanize.com/blog/tag/python/feed/]
+name = Galvanize
 
-[http://gbtami.github.io/feed.python.xml]
-name = Bajusz Tamás
+[http://blog.extracheese.org/feeds/posts/default/-/python]
+name = Gary Bernhardt
 
-[http://gc-taylor.com/?format=rss&category=Python]
-name = Greg Taylor
+[http://feeds.feedburner.com/garyrobinson/python]
+name = Gary Robinson
+
+[http://thegarywilson.com/blog/feed/python/]
+name = Gary Wilson
+
+[http://philipson.co.il/blog/categories/python/atom.xml]
+name = Gavrie Philipson
 
 [http://geekscrap.com/feed/?tag=python]
 name = Geek Scrap
@@ -849,91 +777,167 @@ name = Geek Scrap
 [http://geert.vanderkelen.org/tag/python/feed/atom/]
 name = Geert Vanderkelen
 
+[http://blog.picante.co.nz/latest/feed/]
+name = Gene Campbell
+
+[http://pythonic.pocoo.org/feed.atom]
+name = Georg Brandl
+
+[http://compiletoi.net/feeds/python.atom.xml]
+name = Georges Dubus
+
 [http://ghaandeeonit.tumblr.com/rss]
 name = Ghaandee on IT
+
+[http://www.grodola.blogspot.com/feeds/posts/default/-/python]
+name = Giampaolo Rodola
+
+[http://g.raphaelli.com/tags/python/feed.atom]
+name = Gilad Raphaelli
 
 [http://giuliofidente.com/feeds/tag/python.atom.xml]
 name = Giulio Fidente
 
+[http://hackermojo.com/mt-static/tagged/python.rdf]
+name = Glenn Franxman
+
 [http://glyph.twistedmatrix.com/feeds/posts/default]
 name = Glyph Lefkowitz
 
-[http://gofedora.com/archives/category/python/feed/]
-name = Kulbir Saini
+[http://feeds.feedburner.com/GoDeh]
+name = Go Deh
+
+[https://godjango.com/rss/main/]
+name = GoDjango
+
+[http://blog.gocept.com/tag/python/feed/atom/]
+name = Gocept Weblog
+
+[http://blog.godson.in/feeds/posts/default/-/Python]
+name = Godson Gera
+
+[http://devalien.com/rss.php?module=blog&cat=python]
+name = Gonçalo Margalho
+
+[http://www.curiousvenn.com/?feed=rss2&cat=4]
+name = Graeme Cross
+
+[http://blog.dscpl.com.au/feeds/posts/default]
+name = Graham Dumpleton
 
 [http://gramps-project.org/category/programming/feed/atom/]
 name = Gramps
 
-[http://greenash.net.au/thoughts/topics/python/rss/]
-name = Jeremy Epstein
+[http://defrobnication.blogspot.com/feeds/posts/default/-/python]
+name = Grant Baillie
+
+[http://www.wisdomandwonder.com/tag/python/feed]
+name = Grant Rettke
+
+[http://gc-taylor.com/?format=rss&category=Python]
+name = Greg Taylor
 
 [http://greg-turnquist.blogspot.com/feeds/posts/default/-/spring%20python]
 name = Greg Turnquist
 
-[http://griddlenoise.blogspot.com/feeds/posts/default/-/python]
-name = Jeff Shell
+[http://pyre.third-bit.com/blog/archives/category/python/feed?format=atom]
+name = Greg Wilson
+
+[http://www.answermysearches.com/index.php/category/python/feed/]
+name = Gregory Pinero
+
+[http://agiletesting.blogspot.com/feeds/posts/default/-/python]
+name = Grig Gheorghiu
+
+[http://blog.fizyk.net.pl/tags/python.xml]
+name = Grzegorz Śliwiński
+
+[http://blog.kollerie.com/feeds/Python.atom.xml]
+name = Guido Kollerie
+
+[http://neopythonic.blogspot.com/feeds/posts/default]
+name = Guido van Rossum
+
+[guilhermetoti.com.br/feeds/all.atom.xml]
+name = Guilherme Toti
 
 [http://gustavonarea.net/blog/tags/python/feed/]
 name = Gustavo Narea
 
-[http://hackermojo.com/mt-static/tagged/python.rdf]
-name = Glenn Franxman
+[http://blog.labix.org/tag/python/feed]
+name = Gustavo Niemeyer
 
-[http://hairysun.com/python.xml]
-name = Matt Harrison
+[http://feeds.feedburner.com/gumuznl]
+name = Guyon Moree
 
-[http://halfcooked.com/blog/feed/]
-name = Andy Todd
+[http://pycloud.blogspot.com/feeds/posts/default/-/python]
+name = Gökhan Sever
 
-[http://hashbeat.blogspot.com/feeds/posts/default/-/Python]
-name = Jonathan Dobson
+[http://blog.hannosch.eu/feeds/posts/default/-/python?alt=rss]
+name = Hanno Schlichting
 
-[http://holdenweb.blogspot.com/feeds/posts/default/-/python]
-name = Steve Holden
+[http://blog.vmfarms.com/feeds/posts/default/-/python]
+name = Hany Fahim
 
-[http://housewifehacker.com/rss/category/Python.rss]
-name = Jessie Anderson
+[http://blog.patx.me/rss]
+name = Harrison Erd
 
-[http://hwit.org/feeds/python.atom.xml]
-name = Dave Haynes
+[http://nomadblue.com/feeds/python/]
+name = Hector Garcia
 
-[http://hypatia.ca/tag/python/feed/]
-name = Leigh Honeywell
+[http://www.heikkitoivonen.net/blog/category/python/feed/atom/]
+name = Heikki Toivonen
 
-[http://hypothesis.works/articles/python/feed/]
-name = hypothesis.works articles
+[http://python-in-the-lab.blogspot.de//feeds/posts/default/-/Python]
+name = Hernan Grecco
+
+[http://www.hilarymason.com/tag/python/feed/]
+name = Hilary Mason
+
+[http://tetamap.wordpress.com/feed/atom/]
+name = Holger Krekel
+
+[http://www.holger-peters.de/feeds/python.atom.xml]
+name = Holger Peters
+
+[http://www.huyng.com/atom.xml]
+name = Huy Nguyen
+
+[https://hynek.me/feed-python.xml]
+name = Hynek Schlawack
+
+[http://www.iodigitalsec.com/category/python/feed/]
+name = IO Digital Sec
+
+[http://blog.ianbicking.org/category/python/feed/atom/]
+name = Ian Bicking
 
 [http://ianozsvald.com/category/python/feed/atom/]
 name = Ian Ozsvald
 
-[http://ict.swisscom.ch/tag/python/feed]
-name = Swisscom ICT
-
-[http://ideas.offby1.net/feeds/tag-python.atom.xml]
-name = Chris Rose
-
 [http://ilian.i-n-i.org/feed/?tag=python]
 name = Ilian Iliev
+
+[http://chidjango.dev.imagescape.com/blog/feeds/rss/]
+name = Imaginary Landscape
 
 [http://importpython.com/blog/feed/]
 name = Import Python
 
-[http://importthis.tumblr.com/tagged/python/rss]
-name = Balthazar Rouberol
-
-[http://inre.dundeemt.com/category/python/feed/]
-name = Jeff Hinrichs
-
 [http://intellimath.bitbucket.org/blog/categories/python.xml]
 name = Intellimath blog
-
-[http://interactivepython.org/courselib/feed/everyday.rss]
-name = Everyday Python
 
 [http://inventwithpython.com/blog/feed/atom/]
 name = Invent with Python
 
-[http://ipython0.wordpress.com/feed/atom/]
+[http://www.talaikis.com/python/feed/]
+name = Investing using Python
+
+[https://blog.ionelmc.ro/feeds/python.atom.xml]
+name = Ionel Cristian Mărieș
+
+[http://python123.org/feed/]
+name = Iraj Jelodari
 
 [http://ironpython-urls.blogspot.com/feeds/posts/default]
 name = IronPython-URLs
@@ -941,77 +945,260 @@ name = IronPython-URLs
 [http://ishan.chattopadhyaya.com/blog/?feed=rss2&cat=17]
 name = Ishan Chattopadhyaya
 
-[http://ivory.idyll.org/blog/tags/python?flav=atom]
-name = Titus Brown
+[http://blog.isotoma.com/atom.xml]
+name = Isotoma
+
+[http://fruch.github.io/feed.python.xml]
+name = Israel Fruchter
+
+[http://codewithoutrules.com/python-atom.xml]
+name = Itamar Turner Trauring
+
+[http://radian.org/notebook/feed/atom]
+name = Ivan Krstic
 
 [http://jackdied.blogspot.com/feeds/posts/default]
 name = Jack Diederich
 
-[http://jaredforsyth.com/feeds/category/python/]
-name = Jared Forsyth
+[http://feeds.feedburner.com/StreamHackerPython]
+name = Jacob Perkins
 
-[http://jbisbee.blogspot.com/feeds/posts/default/-/python]
-name = Jeff Bisbee
+[http://wrongsideofmemphis.wordpress.com/feed/atom/?tag=english+python]
+name = Jaime Buelta
 
-[http://jeethurao.com/blog/?feed=rss2&tag=python]
-name = Jeethu Rao
+[http://www.datadependence.com/tag/python/feed/]
+name = Jamal Moir
 
-[http://jeetworks.org/python/feed]
-name = Jeet Sukumaran
+[http://shortcircuit.net.au/~prologic/blog/feeds/tags/python.atom.xml]
+name = James Mills
 
-[http://jeffbradberry.com/feeds/python.atom.xml]
-name = Jeff Bradberry
-
-[http://jeffwinkler.net/category/python/feed]
-name = Jeff Winkler
-
-[http://jeremyhylton.blogspot.com/atom.xml]
-name = Jeremy Hylton
-
-[http://jhcore.com/tag/python/feed]
-name = John Paulett
-
-[http://jjinux.blogspot.com/feeds/posts/default/-/python]
-name = Shannon -jj Behrens
-
-[http://joao.in/blog/category/python/rss/]
-name = João Laia
-
-[http://jonathanstreet.com/blog/tag/python/atom/]
-name = Jonathan Street
+[http://listbot.org/python.xml]
+name = James Polera
 
 [http://jtauber.com/atom/full/]
 name = James Tauber
 
-[http://jugad2.blogspot.co.uk/feeds/posts/default/-/python]
-name = Vasudev Ram
+[http://opkode.net/media/blog/search_rss?portal_type=WeblogEntry&Subject=python]
+name = Jan-Carel Brand
+
+[https://janusworx.com/tag/python/rss]
+name = Janusworx
+
+[http://jaredforsyth.com/feeds/category/python/]
+name = Jared Forsyth
+
+[http://blog.jarrodmillman.com/feeds/posts/default/-/python]
+name = Jarrod Millman
+
+[http://pipes.yahoo.com/pipes/pipe.run?_id=97756b01119b35e1215f3bcbdda71b92&_render=rss]
+name = Jason Baker
+
+[http://www.jasonamyers.com/feed]
+name = Jason Meyers
+
+[http://www.bigjason.com/tags/python.atom]
+name = Jason Webb
+
+[http://ganwell.github.io/feeds/python.atom.xml]
+name = Jean-Louis Fuchs
+
+[http://as.ynchrono.us/feeds/posts/default/-/python]
+name = Jean-Paul Calderone
+
+[http://jeetworks.org/python/feed]
+name = Jeet Sukumaran
+
+[http://jeethurao.com/blog/?feed=rss2&tag=python]
+name = Jeethu Rao
+
+[http://jbisbee.blogspot.com/feeds/posts/default/-/python]
+name = Jeff Bisbee
+
+[http://jeffbradberry.com/feeds/python.atom.xml]
+name = Jeff Bradberry
+
+[http://inre.dundeemt.com/category/python/feed/]
+name = Jeff Hinrichs
+
+[http://www.jeffknupp.com/blog/categories/python/atom.xml]
+name = Jeff Knupp
+
+[http://feeds.feedburner.com/WebInfrastructureSystemsDeploymentsAndTechnologiesPython]
+name = Jeff McNeil
+
+[http://thoughtamps.blogspot.com/feeds/posts/default]
+name = Jeff Rush
+
+[http://griddlenoise.blogspot.com/feeds/posts/default/-/python]
+name = Jeff Shell
+
+[http://jeffwinkler.net/category/python/feed]
+name = Jeff Winkler
+
+[http://greenash.net.au/thoughts/topics/python/rss/]
+name = Jeremy Epstein
+
+[http://jeremyhylton.blogspot.com/atom.xml]
+name = Jeremy Hylton
+
+[http://housewifehacker.com/rss/category/Python.rss]
+name = Jessie Anderson
+
+[http://zyasoft.com/pythoneering/atom.xml]
+name = Jim Baker
+
+[http://www.blogger.com/feeds/6330681631629046724/posts/default]
+name = Jim Fulton
+
+[http://feetup.org/blog/dev/python?flav=rss]
+name = Jim Hughes
+
+[http://pyrseas.wordpress.com/tag/python/feed/atom/]
+name = Joe Abbate
+
+[http://feeds.feedburner.com/JoePitz-TechnologyBlogPython]
+name = Joe Pitz
+
+[http://blogs.gnome.org/johan/category/python/feed/atom]
+name = Johan Dahlin
+
+[http://sontek.net/blog/rss/tag/python.rss]
+name = John Anderson
+
+[http://clouddbs.blogspot.com/feeds/posts/default/-/python]
+name = John Burns
+
+[http://www.johndcook.com/blog/category/python/feed/]
+name = John Cook
+
+[http://www.johngag.com/feed/python/]
+name = John Gagliardi
+
+[http://eigenhombre.com/feed.python.xml]
+name = John Jacobsen
+
+[http://jhcore.com/tag/python/feed]
+name = John Paulett
+
+[http://www.indelible.org/feeds/ink/python.xml]
+name = Jon Parise
+
+[http://hashbeat.blogspot.com/feeds/posts/default/-/Python]
+name = Jonathan Dobson
+
+[http://spyced.blogspot.com/feeds/posts/default/-/python]
+name = Jonathan Ellis
+
+[http://feeds.feedburner.com/JonathansPythonBlog]
+name = Jonathan Harrington
+
+[http://www.tartley.com/?feed=rss2&cat=10]
+name = Jonathan Hartley
+
+[http://www.cleverdevil.org/?rss=1&section=computing]
+name = Jonathan LaCour
+
+[http://jonathanstreet.com/blog/tag/python/atom/]
+name = Jonathan Street
+
+[http://www.jordan-dimov.com/python/atom.xml]
+name = Jordan Dimov
+
+[http://www.metaklass.org/rss/]
+name = Jorge Niedbalski
+
+[http://puentesarr.in/category/python/feed/]
+name = Jorge Puente Sarrín
+
+[http://blog.jorgenschaefer.de/feeds/posts/default/-/Python]
+name = Jorgen Schäfer
+
+[http://joao.in/blog/category/python/rss/]
+name = João Laia
+
+[http://pythonmonopoly.wordpress.com/feed/]
+name = Juan Manuel Contreras
+
+[http://blog.superadditive.com/category/python/feed]
+name = Juan Rivas
+
+[http://www.juanrodriguezmonti.com.ar/tags/python/index.xml]
+name = Juan Rodríguez Monti
+
+[http://nixtu.blogspot.com/feeds/posts/default/-/python]
+name = Juho Vepsäläinen
 
 [http://julien.danjou.info/blog/tags/Python.xml]
 name = Julien Danjou
 
-[http://just-another.net/feeds/tag/python/]
-name = Benjamin W. Smith
+[http://dev-tricks.net/category/code/python/feed]
+name = Julien Palard
+
+[http://beauty-of-imagination.blogspot.fr/feeds/posts/default/-/python]
+name = Julien Tayon
+
+[http://www.iki.fi/juri/blog/index.rss]
+name = Juri Pakaste
+
+[http://pythonisito.blogspot.com/feeds/posts/default]
+name = Just a little Python
+
+[http://feeds.hackercodex.com/feeds/python]
+name = Justin Mayer
+
+[http://diefenba.ch/rss/blog?tags=python]
+name = Kai Diefenbach
+
+[http://lautaportti.wordpress.com/feed/atom/]
+name = Kai Lautaportti
+
+[http://newafricanlifestyle.com/category/python/feed/]
+name = Kamon Ayeva
+
+[http://littlegreenriver.com/weblog/tag/python-2/feed/atom/]
+name = Karen Rustad
 
 [http://kate-editor.org/tag/python/feed/atom/]
 name = Kate Editor
 
+[http://therealkatie.net/blog/python/feed/]
+name = Katie Cunningham
+
+[http://nuitka.net/categories/Python.xml]
+name = Kay Hayen
+
+[http://fiber-space.de/wordpress/category/python/feed]
+name = Kay Schluehr
+
 [http://kbyanc.blogspot.com/feeds/posts/default/-/python]
 name = Kelly Yancey
 
-[http://kendriu.com/feeds/python.atom.xml]
-name = Andrzej Skupień
+[http://www.kennethreitz.org/?category=Development&format=rss]
+name = Kenneth Reitz
 
-[http://kmike.ru/feeds/tags/planet-python.atom.xml]
-name = Mikhail Korobov
+[http://powertwenty.com/kpd/blog/?feed=rss2&cat=3]
+name = Kevin Dahlhausen
+
+[http://www.blueskyonmars.com/category/python/feed/]
+name = Kevin Dangoor
+
+[http://nz.pycon.org/feeds/blog/]
+name = Kiwi PyCon
 
 [http://konryd.blogspot.com/feeds/posts/default]
 name = Konrad Delong
 
-[http://kpoxit.blogspot.com/feeds/posts/default/-/python]
-name = Anton Belyaev
+[https://koodaamo.wordpress.com/category/python/feed]
+name = Koodaamo
 
 [http://kracekumar.com/tagged/python/rss]
 name = Kracekumar Ramaraju
+
+[http://cosmicpercolator.com/category/python/feed/atom/]
+name = Kristján Valur Jónsson
+
+[http://blog.kritigodey.com/tag/python/rss]
+name = Kriti Godey
 
 [http://krys.ca/category/python/feed/atom/1.0/]
 name = Krys Wilken
@@ -1019,7 +1206,13 @@ name = Krys Wilken
 [http://krzysztofzuraw.com/feeds/python.rss.xml]
 name = Krzysztof Żuraw
 
-[http://kunxi.org/archives/category/python/feed]
+[http://gofedora.com/archives/category/python/feed/]
+name = Kulbir Saini
+
+[http://farmdev.com/feeds/thoughts/on/3/python/]
+name = Kumar McMillan
+
+[http://www.kunxi.org/tag/python/feed]
 name = Kun Xi
 
 [http://kurtgrandis.com/blog/category/python/feed]
@@ -1028,20 +1221,29 @@ name = Kurt Grandis
 [http://kushaldas.in/categories/python.xml]
 name = Kushal Das
 
-[http://labs.creativecommons.org/category/python/feed/]
-name = Creative Commons
+[http://charlesnagy.info/category/it/python/feed/]
+name = Károly Nagy
 
-[http://late.am/python.feed.xml]
-name = Dan Crosta
+[http://feeds.feedburner.com/shuttlethread-python]
+name = Laurence Rowe
+
+[http://www.laurentluce.com/posts/tag/python/feed/]
+name = Laurent Luce
 
 [http://laurentszyster.be/blog/feed/]
 name = Laurent Szyster
 
-[http://lautaportti.wordpress.com/feed/atom/]
-name = Kai Lautaportti
+[http://feeds2.feedburner.com/ASongForTheLovers]
+name = Lawrence Oluyede
 
-[http://learnpython.wordpress.com/feed/atom/]
-name = Naomi Ceder
+[http://blog.irukado.org/category/python/feed/]
+name = Lee Braiden
+
+[http://hypatia.ca/tag/python/feed/]
+name = Leigh Honeywell
+
+[http://regebro.wordpress.com/category/python/feed/atom/]
+name = Lennart Regebro
 
 [http://leovt.wordpress.com/category/python/feed/atom/]
 name = Leonhard Vogt
@@ -1052,11 +1254,14 @@ name = Lesscode.org
 [http://levipy.com/python_feed.xml]
 name = Levi Velázquez
 
-[http://lewk.org/blog/tags/Python?flav=atom]
-name = Luke Macken
+[http://www.lfcproject.com/feeds/django]
+name = Lightning Fast CMS
 
-[http://linil.wordpress.com/feed/atom/]
-name = Rodrigo Araúj
+[http://www.getlfs.com/rss/blog]
+name = Lightning Fast Shop
+
+[http://blog.lintel.in/tag/python/feed/]
+name = Lintel Technologies
 
 [http://lion.posterous.com/rss.xml?tag=planetpython]
 name = Lion Kimbro
@@ -1064,29 +1269,26 @@ name = Lion Kimbro
 [http://lionel.textmalaysia.com/category/programming/python/feed]
 name = Lionel Tan
 
-[http://lipyrary.blogspot.com/feeds/posts/default]
-name = Christian Heimes
-
-[http://listbot.org/python.xml]
-name = James Polera
-
-[http://littlegreenriver.com/weblog/tag/python-2/feed/atom/]
-name = Karen Rustad
-
-[http://livingcode.org/tag/python.atom]
-name = Dethe Elza
-
-[http://lostinjit.blogspot.com/feeds/posts/default]
-name = Maciej Fijalkowsk
+[http://feeds.feedburner.com/logilaborg_en]
+name = Logilab
 
 [http://lowkster.blogspot.com/feeds/posts/default]
 name = Low Kian Seong
 
-[http://lucumr.pocoo.org/feed.atom]
-name = Armin Ronacher
+[http://codingandlinux.blogspot.com/feeds/posts/default/-/python]
+name = Luca Botti
 
-[http://lukasz.langa.pl/feed/tag/python/rss-en.xml]
-name = Łukasz Langa
+[http://blog.gmludo.eu/feeds/posts/default/-/python]
+name = Ludovic Gasc
+
+[http://blog.ludovf.net/feed/python/atom/]
+name = Ludovico Fischer
+
+[http://bsg.lericson.se/rssfiltered.rss]
+name = Ludvig Ericson
+
+[http://lewk.org/blog/tags/Python?flav=atom]
+name = Luke Macken
 
 [http://lukeplant.me.uk/blog/categories/python/atom/index.xml]
 name = Luke Plant
@@ -1094,35 +1296,110 @@ name = Luke Plant
 [http://machinalis.com/blog/tag/python/feeds/rss/]
 name = Machinalis
 
-[http://makkalot-opensource.blogspot.com/feeds/posts/default/-/python]
-name = Denis Kurov
+[http://lostinjit.blogspot.com/feeds/posts/default]
+name = Maciej Fijalkowsk
 
-[http://mancoosi.org/~abate/taxonomy/term/56/0/feed]
-name = Pietro Abate
+[http://www.mahdiyusuf.com/tagged/python/rss]
+name = Mahdi Yusuf
+
+[http://sedimental.org/tagged/python/atom.xml]
+name = Mahmoud Hashemi
+
+[https://maltheborch.com/rss?tags=python]
+name = Malthe Borch
+
+[http://www.themacaque.com/?tag=python&feed=rss2]
+name = Manuel de la Pena Saenz
+
+[http://vaig.be/feeds/posts/default/-/Python]
+name = Marc Garcia
+
+[http://www.malemburg.com/rss]
+name = Marc-André Lemburg
+
+[http://www.python-blog.com/feed/atom/]
+name = Marcin Kuźmiński
+
+[http://www.grulic.org.ar/~mdione/glob/tags/python/index.atom]
+name = Marcos Dione
 
 [http://marcuswhybrow.net/tag/python/feed/atom/]
 name = Marcus Whybrow
 
-[http://marduk.ghost.io/tag/python/rss/]
-name = Albert Hopkins
+[http://pysnippet.com/feeds/posts/default/-/Python]
+name = Mario Boikov
 
-[http://markos.gaivo.net/articles/feeds/python.atom.xml]
-name = Marko Samastur
+[http://mg.pov.lt/blog/index.xml]
+name = Marius Gedminas
+
+[http://stochasticgeometry.com/category/python/feed/atom/]
+name = Mark Dennehy
+
+[http://shed-skin.blogspot.com/feeds/posts/default]
+name = Mark Dufour
+
+[http://blogs.gnome.org/markmc/category/python/feed/]
+name = Mark McLoughlin
+
+[http://pywinauto.blogspot.com/atom.xml]
+name = Mark McMahon
+
+[http://www.learningpython.com/feed/]
+name = Mark Mruss
 
 [http://markpasc.org/weblog/index.rdf]
 name = Mark Paschal
 
+[http://compoundthinking.com/blog/index.php/category/python/feed]
+name = Mark Ramm
+
+[http://markos.gaivo.net/articles/feeds/python.atom.xml]
+name = Marko Samastur
+
+[http://blog.startifact.com/categories/planetpython.xml]
+name = Martijn Faassen
+
+[http://feeds.feedburner.com/zopatista/python]
+name = Martijn Pieters
+
+[http://furius.ca/blog/tag/Python/rss]
+name = Martin Blais
+
 [http://martinfitzpatrick.name/feeds/python.tag.atom.xml]
 name = Martin Fitzpatrick
 
-[http://masnun.rocks/tags/python/index.xml]
-name = Abu Ashraf Masnun
+[http://stompstompstomp.com/weblog/technical/rss]
+name = Mathieu Fenniak
+
+[http://txzone.net/category/python/feed]
+name = Mathieu Virbel
+
+[http://mysqlmusings.blogspot.se/feeds/posts/default/-/python]
+name = Mats Kindahl
 
 [http://mattgoodall.blogspot.com/atom.xml]
 name = Matt Goodall
 
+[http://hairysun.com/python.xml]
+name = Matt Harrison
+
+[http://themattreid.com/wordpress/category/python/feed/]
+name = Matt Reid
+
+[http://www.circulartriangle.com/blog/?feed=atom&tag=python]
+name = Matt Wilkes
+
 [http://matthewrocklin.com/blog/feed.python.xml]
 name = Matthew Rocklin
+
+[http://www.stealthcopter.com/blog/tag/python/feed/]
+name = Matthew Rollings
+
+[http://blog.tplus1.com/index.php/category/python/feed]
+name = Matthew Wilson
+
+[http://copypasteprogrammer.blogspot.com/feeds/posts/default/-/python]
+name = Mattias Brändström
 
 [http://mauveweb.co.uk/rss.xml]
 name = Mauveweb
@@ -1130,17 +1407,32 @@ name = Mauveweb
 [http://maxischenko.in.ua/planet_python/]
 name = Max Ischenko
 
+[http://blog.klymyshyn.com/feeds/posts/default/-/python]
+name = Max Klymyshyn
+
+[http://freshfoo.com/blog/index.atom]
+name = "Menno's Musings"
+
+[http://techspot.zzzeek.org/?feed=rss2]
+name = Michael Bayer
+
+[http://beckerfuffle.com/blog/categories/python/atom.xml]
+name = Michael Becker
+
+[http://mike.crute.org/blog/tag/python/feed]
+name = Michael Crute
+
 [http://mdboom.github.io/feeds/all.atom.xml]
 name = Michael Droettboom
 
-[http://metachris.org/category/python/feed/atom/]
-name = Chris Hager
+[http://feeds.feedburner.com/voidspace]
+name = Michael Foord
 
-[http://mg.pov.lt/blog/index.xml]
-name = Marius Gedminas
+[http://starship.python.net/crew/mwh/blog/nb.cgi/syndicate/weblog/python]
+name = Michael Hudson
 
-[http://michael.susens-schurter.com/blog/category/technology/python/feed]
-name = Michael Schurter
+[http://mjtokelly.blogspot.com/feeds/posts/default/-/Python]
+name = "Michael J.T. O'Kelly"
 
 [http://michaelmartinez.in/feeds/python.rss.xml]
 name = Michael Martinez
@@ -1148,974 +1440,146 @@ name = Michael Martinez
 [http://micknelson.wordpress.com/category/python/feed/atom/]
 name = Michael Nelson
 
-[http://mike.crute.org/blog/tag/python/feed]
-name = Michael Crute
+[http://michael.susens-schurter.com/blog/category/technology/python/feed]
+name = Michael Schurter
 
-[http://mikenaberezny.com/category/python/?feed=rss]
-name = Mike Naberezny
+[http://yeoldeclue.com/cgi-bin/blog/food.cgi]
+name = Michael Sparks
 
 [http://mikewatkins.ca/tags/python/feeds/atom]
 name = Michael Watkins
 
-[http://mindref.blogspot.com/feeds/posts/default/-/python]
-name = Andriy Kornatskyy
-
-[http://mindtrove.info/tag/python/feed/index.xml]
-name = Peter Parente
-
-[http://mjtokelly.blogspot.com/feeds/posts/default/-/Python]
-name = "Michael J.T. O'Kelly"
-
-[http://montrealpython.com/feed/]
-name = Montreal Python User Group
-
-[http://morepypy.blogspot.com/feeds/posts/default]
-name = PyPy Development
-
 [http://mousebender.wordpress.com/feed/atom/]
 name = Michal Kwiatkowski
 
-[http://mrben.co.uk/feed/python/]
-name = Ben Tappin
-
-[http://muharem.wordpress.com/feed/atom/]
-name = Muharem Hrnjadovic
-
-[http://myownhat.blogspot.com/feeds/posts/default/-/python]
-name = Tennessee Leeuwenburg
-
-[http://mysql-python.blogspot.com/feeds/posts/default]
-name = Andy Dustman
-
-[http://mysqlmusings.blogspot.se/feeds/posts/default/-/python]
-name = Mats Kindahl
-
-[http://nadiana.com/category/python/feed]
-name = Nadia Alramli
-
-[http://naeblis.cx/rtomayko/weblog/python/index.rdf]
-name = Ryan Tomayko
-
-[http://nedbatchelder.com/blog/planetpython.xml]
-name = Ned Batchelder
-
-[http://neopythonic.blogspot.com/feeds/posts/default]
-name = Guido van Rossum
-
-[http://neovox.advancedmagic.de/?feed=rss2&cat=6]
-name = Peter Fankhänel
-
-[http://newafricanlifestyle.com/category/python/feed/]
-name = Kamon Ayeva
-
-[http://news.e-scribe.com/feeds/tag/python/atom.xml]
-name = Paul Bissex
-
-[http://news.open-bio.org/news/category/obf-projects/biopython/feed/atom/]
-name = BioPython News
-
-[http://nicdumz.fr/blog/category/python/feed/index.xml]
-name = Nicolas Dumazet
-
-[http://nichol.as/tags/python/feed]
-name = Nicholas Piël
-
-[http://nickjanetakis.blogspot.com/feeds/posts/default/-/python]
-name = Nick Janetakis
-
-[http://nicoddemus.github.io/tag/python/atom.xml]
-name = Bruno Oliveira
-
-[http://nicolaiarocci.com/tags/python/index.xml]
-name = Nicola Iarocci
-
-[http://nigelb.me/python.xml]
-name = Nigel Babu
-
-[http://nixtu.blogspot.com/feeds/posts/default/-/python]
-name = Juho Vepsäläinen
-
-[http://nl-project.blogspot.com/feeds/posts/default/-/python]
-name = nl-project
-
-[http://nomadblue.com/feeds/python/]
-name = Hector Garcia
-
-[http://nuitka.net/categories/Python.xml]
-name = Kay Hayen
-
-[http://nz.pycon.org/feeds/blog/]
-name = Kiwi PyCon
-
-[http://oakwinter.com/code/category/python/feed/rss]
-name = Collin Winter
-
-[http://omar.toomuchcookies.net/node/category/programming/python/feed/]
-name = Omar Abo-Namous
-
-[http://ondrejcertik.blogspot.com/feeds/posts/default/-/python]
-name = Ond&#345;ej &#268;ert&iacute;k
-
-[http://online.effbot.org/rss.xml]
-name = Fredrik Lundh
-
-[http://openhatch.org/blog/tag/python/feed/atom/]
-name = OpenHatch Python posts
-
-[http://opensourcehacker.com/category/python/feed/]
-name = Mikko Ohtamaa
-
-[http://opkode.net/media/blog/search_rss?portal_type=WeblogEntry&Subject=python]
-name = Jan-Carel Brand
-
-[http://orestis.gr/feeds/tag/python/en/]
-name = Orestis Markou
-
-[http://oubiwann.blogspot.com/feeds/posts/default/-/python]
-name = Duncan McGreggor
-
-[http://pauleveritt.wordpress.com/feed/atom/]
-name = Paul Everitt
-
-[http://pbpython.com/feeds/all.atom.xml]
-name = Chris Moffitt
-
-[http://peadrop.com/blog/category/python/feed/]
-name = Alexandre Vassalotti
-
-[http://pedro.valelima.com/blog/feed/tag/python/]
-name = Pedro Lima
-
-[http://pedrokroger.net/category/python/feed/]
-name = Pedro Kroger
-
-[http://percious.com/blog/feed]
-name = Chris Perkins
-
-[http://peter-hoffmann.com/feed/atom-python.xml]
-name = Peter Hoffmann
-
-[http://petereisentraut.blogspot.com/feeds/posts/default/-/Python/]
-name = Peter Eisentraut
-
-[http://petro.tanrei.ca/categories/python/feed.atom]
-name = Petro Verkhogliad
-
-[http://pfertyk.me/feeds/python.atom.xml]
-name = Paweł Fertyk
-
-[http://pgcli.com/feeds/tag.python.atom.xml]
-name = pgcli
-
-[http://philikon.wordpress.com/category/python/feed/atom/]
-name = Philipp von Weitershausen
-
-[http://philipson.co.il/blog/categories/python/atom.xml]
-name = Gavrie Philipson
-
-[http://philosophyofweb.com/category/python/feed/]
-name = Ted Nyman
-
-[http://pieceofpy.com/category/python/feed/atom/index.xml]
-name = Wayne Witzel
-
-[http://pipes.yahoo.com/pipes/pipe.run?_id=97756b01119b35e1215f3bcbdda71b92&_render=rss]
-name = Jason Baker
-
-[http://pkaudio.blogspot.com/feeds/posts/default/-/python]
-name = Patrick Stinson
-
-[http://pl.pycon.org/2015/en/rss-aktualnosci]
-name = PyCon PL Conference
-
-[http://plope.com/python.rss]
-name = Chris McDonough
-
-[http://plumberjack.blogspot.com/feeds/posts/default]
-name = Vinay Sajip (Logging)
-
-[http://posted-stuff.blogspot.com/feeds/posts/default/-/python]
-name = Richard Tew
-
-[http://powertwenty.com/kpd/blog/?feed=rss2&cat=3]
-name = Kevin Dahlhausen
-
-[http://pp.com.mx/blog/topics/python/feed/atom/]
-name = Patricio Paez
-
-[http://pragmaticpython.com/feed/?tag=python]
-name = Tomasz Früboes
-
-[http://prayogshala.wordpress.com/category/scripting/python/feed/atom/]
-name = Varun Nischal
-
-[http://programandociencia.com/category/english/feed/]
-name = Programando Ciência
-
-[http://ptspts.blogspot.com/feeds/posts/default/-/planet-python]
-name = Péter Szabó
-
-[http://puentesarr.in/category/python/feed/]
-name = Jorge Puente Sarrín
-
-[http://push.cx/tag/python/feed]
-name = Peter Harkins
-
-[http://pyarab.blogspot.se/atom.xml]
-name = بايثون العربي
-
-[http://pybit.es/feeds/all.rss.xml]
-name = PyBites
-
-[http://pybites.blogspot.com/feeds/posts/default]
-name = Benjamin Peterson
-
-[http://pycloud.blogspot.com/feeds/posts/default/-/python]
-name = Gökhan Sever
-
-[http://pydev.blogspot.com/atom.xml]
-name = Fabio Zadrozny
-
-[http://pyfound.blogspot.com/atom.xml]
-name = Python Software Foundation
-
-[http://pyfunc.blogspot.com/feeds/posts/default/-/python]
-name = Ashish Vidyarthi
-
-[http://pyinformatics.blogspot.com/feeds/posts/default]
-name = Chris Mitchell
-
-[http://pyinsci.blogspot.com/feeds/posts/default]
-name = Flavio Coelho
-
-[http://pyladies.com/blog/feeds/atom/]
-name = PyLadies
-
-[http://pylonshq.com/articles.atom]
-name = Pylons News Feed
-
-[http://pymolurus.blogspot.com/feeds/posts/default]
-name = Vinay Sajip
-
-[http://pyre.third-bit.com/blog/archives/category/python/feed?format=atom]
-name = Greg Wilson
-
-[http://pyright.blogspot.com/feeds/posts/default?alt=rss]
-name = Carl Trachte
-
-[http://pyrseas.wordpress.com/tag/python/feed/atom/]
-name = Joe Abbate
-
-[http://pysnippet.com/feeds/posts/default/-/Python]
-name = Mario Boikov
-
-[http://pyswarm.blogspot.com/feeds/posts/default]
-name = Anastasios Hatzis
-
-[http://pytennessee.tumblr.com/rss]
-name = PyTennessee
-
-[http://python-academy.blogspot.com/feeds/posts/default]
-name = Mike Müller
-
-[http://python-advocacy.blogspot.com/atom.xml]
-name = Python Advocacy
-
-[http://python-catalin.blogspot.com/feeds/posts/default/-/python]
-name = Catalin George Festila
-
-[http://python-groups.blogspot.com/feeds/posts/default]
-name = Python User Groups
-
-[http://python-in-the-lab.blogspot.de//feeds/posts/default/-/Python]
-name = Hernan Grecco
-
-[http://python-karan.blogspot.in//feeds/posts/default]
-name = Python on Karan
-
-[http://python-open-mike.posterous.com/rss.xml]
-name = Python Open Mike
-
-[http://python-weekly.blogspot.com/feeds/posts/default?alt=rss]
-name = Weekly Python StackOverflow Report
-
-[http://python.ca/nas/log/rss-python.xml]
-name = Neil Schemenauer
-
-[http://python.genedrift.org/feed/]
-name = Paulo Nuin
-
-[http://python.scripting.com/xml/rss.xml]
-name = Scripting the web with Python
-
-[http://python123.org/feed/]
-name = Iraj Jelodari
-
-[http://python4dads.wordpress.com/feed/]
-name = Brendan Scott
-
-[http://python4kids.wordpress.com/feed/atom/]
-name = Python 4 Kids
-
-[http://pythonbyexample.blogspot.com/feeds/posts/default/]
-name = Mitya Sirenef
-
-[http://pythonclub.com.br/feeds/all.atom.xml]
-name = PythonClub - A Brazilian collaborative blog about Python
-
-[http://pythonconquerstheuniverse.wordpress.com/feed/atom/]
-name = Stephen Ferg
-
-[http://pythondata.com/feed/]
-name = Python Data
-
-[http://pythondoeswhat.blogspot.com/feeds/posts/default]
-name = Python Does What?!
-
-[http://pythonfilter.com/rss.xml]
-name = "Eric Wu's Pythonfilter"
-
-[http://pythonforbiologists.com/index.php/category/python/feed/]
-name = Python for biologists
-
-[http://pythonic.pocoo.org/feed.atom]
-name = Georg Brandl
-
-[http://pythonide.blogspot.com/feeds/posts/default]
-name = SPE Weblog
-
-[http://pythonisito.blogspot.com/feeds/posts/default]
-name = Just a little Python
-
-[http://pythonmonopoly.wordpress.com/feed/]
-name = Juan Manuel Contreras
-
-[http://pythonology.blogspot.com/atom.xml]
-name = Pythonology
-
-[http://pythonpapers.blogspot.com/atom.xml]
-name = The Python Papers
-
-[http://pythonsprints.com/feeds/latest/]
-name = Python Sprints
-
-[http://pythonsweetness.tumblr.com/rss]
-name = Python Sweetness
-
-[http://pythontesting.net/on/planet/feed]
-name = Brian Okken
-
-[http://pythontestingcookbook.posterous.com/rss.xml]
-name = Python Testing Cookbook
-
-[http://pythonthusiast.pythonblogs.com/230_pythonthusiast/feeds/rss20]
-name = Eko S. Wibowo
-
-[http://pythonxynews.blogspot.com/feeds/posts/default]
-name = Python(x,y) News
-
-[http://pywinauto.blogspot.com/atom.xml]
-name = Mark McMahon
-
-[http://radar.wiredobjects.eu/category/python/feed/]
-name = wiredobjects
-
-[http://radian.org/notebook/feed/atom]
-name = Ivan Krstic
-
-[http://ramblings.timgolden.me.uk/category/tech/python/feed/]
-name = Tim Golden
-
-[http://randlet.com/blog/python/rss.xml]
-name = Randle Taylor
-
-[http://randyzwitch.com/tag/python/feed/]
-name = Randy Zwitch
-
-[http://raspberry-python.blogspot.com/feeds/posts/default/-/english/python]
-name = François Dion
-
-[http://rayli.net/blog/tag/planetpython/feed/]
-name = Raymond Li
-
-[http://rbtcollins.wordpress.com/tag/python/feed/atom/]
-name = Robert Collins
-
-[http://reachtim.com/feeds/python.atom.xml]
-name = Reach Tim
-
-[http://regebro.wordpress.com/category/python/feed/atom/]
-name = Lennart Regebro
-
-[http://reinout.vanrees.org/weblog/plonefeed.xml]
-name = Reinout van Rees
-
-[http://renesd.blogspot.com/feeds/posts/default/-/python]
-name = Rene Dudfield
-
-[http://rgomes-info.blogspot.co.uk/feeds/posts/default/-/python]
-name = Richard Gomes
-
-[http://rh0dium.blogspot.com/feeds/posts/default/-/python]
-name = Steven Klass
-
-[http://rhettinger.wordpress.com/feed/atom/]
-name = Raymond Hettinger
-
-[http://rhodesmill.org/brandon/category/python/feed]
-name = Brandon Rhodes
-
-[http://robert-lujo.com/tagged/python/rss]
-name = Robert Lujo
-
-[http://robert.io/blog/categories/python/atom.xml]
-name = Robert Picard
-
-[http://ruslanspivak.com/category/python/feed/atom/]
-name = Ruslan Spivak
-
-[http://rz.scale-it.pl/rss-python.html]
-name = Robert Zaremba
-
-[http://s3.amazonaws.com/blog.pathwright.com/feeds/tag.Python.atom.xml]
-name = Pathwright
-
-[http://sandbox.rulemaker.net/ngps/rdf10_python_xml]
-name = Ng Pheng Siong
-
-[http://sandrotosi.blogspot.com/feeds/posts/default/-/Python]
-name = Sandro Tosi
-
-[http://scrollingtext.org/taxonomy/term/29/0/feed]
-name = Bryce Verdier
-
-[http://scummos.blogspot.com/feeds/posts/default/-/kdev-python]
-name = kdev-python
-
-[http://seanmcgrath.blogspot.com/feeds/posts/default/-/python]
-name = Sean McGrath
-
-[http://sedimental.org/tagged/python/atom.xml]
-name = Mahmoud Hashemi
-
-[http://shed-skin.blogspot.com/feeds/posts/default]
-name = Mark Dufour
-
-[http://shiningpanda.com/feeds/all.atom.xml]
-name = ShiningPanda
-
-[http://shortcircuit.net.au/~prologic/blog/feeds/tags/python.atom.xml]
-name = James Mills
-
-[http://shriphani.com/blog/category/python/feed]
-name = Shriphani Palakodety
-
-[http://simeonfranklin.com/feeds/python/]
-name = Simeon Franklin
-
-[http://simonwillison.net/atom/tagged/python/]
-name = Simon Willison
-
-[http://sites.google.com/site/pydatalog/pypl/python-blog/posts.xml]
-name = Pierre Carbonnelle
-
-[http://slott-softwarearchitect.blogspot.com/feeds/posts/default/-/python]
-name = S. Lott
-
-[http://sontek.net/blog/rss/tag/python.rss]
-name = John Anderson
-
-[http://source.mihelac.org/feeds/categories/django/]
-name = Bojan Mihelac
-
-[http://speno.blogspot.com/atom.xml]
-name = "Speno's Pythonic Avocado"
-
-[http://spikeekips.tumblr.com/tagged/python/rss]
-name = Spike ekipS
-
-[http://spyced.blogspot.com/feeds/posts/default/-/python]
-name = Jonathan Ellis
-
-[http://spyder-ide.blogspot.com/feeds/posts/default]
-name = Spyder IDE
-
-[http://ssutch.org/tag/python/feed]
-name = Samuel Sutch
-
-[http://stackabuse.com/tag/python/rss]
-name = Stack Abuse
-
-[http://stacks.11craft.com/feeds/tag.python.atom.xml]
-name = Stacks
-
-[http://starship.python.net/crew/mwh/blog/nb.cgi/syndicate/weblog/python]
-name = Michael Hudson
-
-[http://stdout.be/tag/django/feed/]
-name = Stijn Debrouwere
-
-[http://stefan.sofa-rockers.org/feeds/python]
-name = Stefan Scherfke
-
-[http://stevedower.id.au/blog/category/python/feed/]
-name = Steve Dower
-
-[http://stochasticgeometry.com/category/python/feed/atom/]
-name = Mark Dennehy
-
-[http://stompstompstomp.com/weblog/technical/rss]
-name = Mathieu Fenniak
-
-[http://strombrg.blogspot.com/feeds/posts/default/-/Python]
-name = Dan Stromberg
-
-[http://sumith1896.github.io/feeds/feed.sympy.xml]
-+name = Sumith - Blog about SymPy/Python
-
-[http://swaroopch.com/tag/python/feed/]
-name = Swaroop C H
-
-[http://swiftstack.com/blog/python.xml]
-name = SwiftStack
-
-[http://swordstyle.com/blog2/?feed=rss2&cat=20]
-name = Terry Peppers
-
-[http://tech.blog.aknin.name/tag/python/feed/atom/]
-name = Yaniv Aknin
-
-[http://techarttiki.blogspot.com/feeds/posts/default/-/python]
-name = Adam Pletcher
-
-[http://techblog.ironfroggy.com/feeds/posts/default/-/programming]
-name = Calvin Spealman
-
-[http://technicaldiscovery.blogspot.com/feeds/posts/default/-/python]
-name = Travis Oliphant
-
-[http://techspot.zzzeek.org/?feed=rss2]
-name = Michael Bayer
-
-[http://techtonik.rainforce.org/feeds/posts/default/-/python]
-name = Anatoly Techtonik
-
-[http://terriko.dreamwidth.org/data/rss?tag=python]
-name = Terri Oda
-
-[http://tetamap.wordpress.com/feed/atom/]
-name = Holger Krekel
-
-[http://the-space-station.com/tags/planet-python/feed.atom]
-name = Christopher Denter
-
-[http://thechangelog.com/tagged/python/rss]
-name = The Changelog
-
-[http://thegarywilson.com/blog/feed/python/]
-name = Gary Wilson
-
-[http://thelivingpearl.com/tag/python/feed/]
-name = Captain DeadBones'' Chronicles
-
-[http://themattreid.com/wordpress/category/python/feed/]
-name = Matt Reid
-
-[http://themindcaster.blogspot.com/feeds/posts/default/-/python]
-name = Carlos Eduardo de Paula
-
-[http://therealkatie.net/blog/python/feed/]
-name = Katie Cunningham
-
-[http://thewebhaswon.wordpress.com/category/python/atom]
-name = Tom Christie
-
-[http://thomas.apestaart.org/log/?feed=rss2&cat=22]
-name = Thomas Vander Stichele
-
-[http://thoughtamps.blogspot.com/feeds/posts/default]
-name = Jeff Rush
-
-[http://thppython.blogspot.com/feeds/posts/default]
-name = David Janes
-
-[http://threebean.org/blog/category/python/feed/atom/index.xml]
-name = Ralph Bean
-
-[http://tillenius.me/feeds/atom/tag/python/]
-name = Björn Tillenius
-
-[http://timgilbert.wordpress.com/category/python/feed/atom/]
-name = Tim Gilbert
-
-[http://tomerfiliba.com/blog/python-atom.xml]
-name = Tomer Filiba
-
-[http://tonybreyal.wordpress.com/category/python/feed/atom/]
-name = Tony Breyal
-
-[http://touilleman.xyz/blog/category/python/feed/index.xml]
-name = Emmanuel Leblond
-
-[http://treyhunner.com/python.xml]
-name = Trey Hunner
-
-[http://txzone.net/category/python/feed]
-name = Mathieu Virbel
-
-[http://uberpython.wordpress.com/tag/python/feed/atom/]
-name = Yuval Greenfield
-
-[http://un-pythonic.appspot.com/feeds/atom.xml]
-name = Ali Afshar
-
-[http://united-coders.com/taxonomy/term/22/0/feed]
-name = United Coders
-
-[http://vaig.be/feeds/posts/default/-/Python]
-name = Marc Garcia
-
-[http://vsbabu.org/mt/index.rdf]
-name = V.S. Babu
-
-[http://weblog.lonelylion.com/category/python/feed]
-name = Chris McAvoy
-
-[http://weblog.patrice.ch/tags/Python.atom]
-name = Patrice Neff
-
-[http://wescpy.blogspot.com/feeds/posts/default/-/python]
-name = Wesley Chun
-
-[http://westmarch.sjsoft.com/tag/python/feed/]
-name = St James Software Development
-
-[http://william-os4y.livejournal.com/data/atom]
-name = "William's Journal"
-
-[http://willpython.blogspot.com/feeds/posts/default]
-name = Will Pierce
-
-[http://wingware.com/blog/rss&noheader=1]
-name = Wingware Blog
-
-[http://wingware.com/news/rss&noheader=1]
-name = Wingware News
-
-[http://wirtel.be/tags/python/index.xml]
-name = Stéphane Wirtel
-
-[http://wokslog.wordpress.com/tag/python/feed/atom/]
-name = Éric Araujo
-
-[http://wolfram.kriesing.de/blog/index.php/category/programming/python/feed]
-name = Wolfram Kriesing
-
-[http://wrongsideofmemphis.wordpress.com/feed/atom/?tag=english+python]
-name = Jaime Buelta
-
-[http://www.2general.com/blog/python.rss.html]
-name = 2General
-
-[http://www.alexconrad.org/feeds/posts/default/-/python]
-name = Alexandre Conrad
-
-[http://www.aminus.org/blogs/xmlsrv/rss2.php?blog=2&cat=15]
-name = Robert Brewer
-
-[http://www.andreagrandi.it/category/python/feed/]
-name = Andrea Grandi
-
-[http://www.answermysearches.com/index.php/category/python/feed/]
-name = Gregory Pinero
-
-[http://www.appneta.com/blog/tag/python-applications/feed/]
-name = AppNeta Blog
-
-[http://www.artima.com/weblogs/feeds/bloggers/aahz.rss]
-name = Aahz
-
-[http://www.artima.com/weblogs/feeds/bloggers/goodger.rss]
-name = David Goodger
+[https://bultrowicz.com/blog/tag/python/atom.xml]
+name = Michał Bultrowicz
+
+[http://blog.mdomans.com/rss/python/]
+name = Michał Domański
 
 [http://www.artima.com/weblogs/feeds/bloggers/micheles.rss]
 name = Michele Simionato
 
-[http://www.asciiarmor.com/tagged/python/rss]
-name = Ryan Cox
+[http://www.firsttimeprogrammer.blogspot.com/feeds/posts/default/-/python?alt=rss]
+name = Michy Alice
 
-[http://www.awaretek.com/python/index.xml]
-name = Python 411 Podcast
-
-[http://www.bedjango.com/planet/feed/]
-name = BeDjango
-
-[http://www.benjiyork.com/blog/atom.xml]
-name = Benji York
-
-[http://www.bigjason.com/tags/python.atom]
-name = Jason Webb
-
-[http://www.bitdance.com/blog/rss.xml]
-name = R David Murray
-
-[http://www.blendedtechnologies.com/category/python/rss/]
-name = Blended Technologies
+[http://blog.vrplumber.com/index.php?/feeds/categories/1-Snaking.rss]
+name = Mike C. Fletcher
 
 [http://www.blog.pythonlibrary.org/feed/]
 name = Mike Driscoll
 
-[http://www.blogger.com/feeds/6330681631629046724/posts/default]
-name = Jim Fulton
+[http://python-academy.blogspot.com/feeds/posts/default]
+name = Mike Müller
 
-[http://www.blueskyonmars.com/category/python/feed/]
-name = Kevin Dangoor
+[http://mikenaberezny.com/category/python/?feed=rss]
+name = Mike Naberezny
 
-[http://www.brunningonline.net/simon/blog/index-P.xml]
-name = Simon Brunning
-
-[http://www.caktusgroup.com/feeds/tags/python/]
-name = Caktus Consulting Group
-
-[http://www.calvinx.com/category/code/python/feed/]
-name = Calvin Cheng
-
-[http://www.checkandshare.com/blog/?cat=2?&feed=rss2]
-name = Checking and Sharing
-
-[http://www.chesnok.com/daily/category/python/feed/]
-name = Selena Deckelmann
-
-[http://www.chrisbarra.me/tags/python.xml]
-name = Christian Barra
-
-[http://www.circulartriangle.com/blog/?feed=atom&tag=python]
-name = Matt Wilkes
-
-[http://www.cleverdevil.org/?atom=1&section=computing]
-name = Jonathan LaCour
-
-[http://www.cleverdevil.org/?rss=1&section=computing]
-name = Jonathan LaCour
-
-[http://www.cmlenz.net/blog/python.xml]
-name = Christopher Lenz
-
-[http://www.codemakesmehappy.com/feeds/posts/default/-/Python]
-name = Audrey Roy Greenfeld
-
-[http://www.coresoftwaregroup.com/blog/topics/python/@@rss.xml]
-name = Core Software
-
-[http://www.craig-wood.com/nick/articles/category/python/feed/atom/index.xml]
-name = Nick Craig-Wood
-
-[http://www.curiousefficiency.org/categories/python.xml]
-name = Nick Coghlan
-
-[http://www.curiousvenn.com/?feed=rss2&cat=4]
-name = Graeme Cross
-
-[http://www.damian.oquanta.info/categories/python.xml]
-name = Damián Avila
-
-[http://www.datadependence.com/tag/python/feed/]
-name = Jamal Moir
-
-[http://www.dataschool.io/tag/python/rss/]
-name = Data School
-
-[http://www.davidgrant.ca/taxonomy/term/14/0/feed]
-name = David Grant
-
-[http://www.defuze.org/archives/category/python/feed]
-name = Sylvain Hellegouarch
-
-[http://www.devpicayune.com/category/python/feed]
-name = Steven Wilcox
-
-[http://www.diego-garcia.info/python.atom.xml]
-name = Diego Garcia
-
-[http://www.djangocon.org/blog/feeds/rss/latest/]
-name = Djangocon
-
-[http://www.djangofoo.com/feed]
-name = Djangofeed
-
-[http://www.djangoproject.com/rss/weblog/]
-name = Django Weblog
-
-[http://www.djangotimes.com/feeds/posts/all/]
-name = Washington Times OpenSource
-
-[http://www.djangrrl.com/feeds/python/]
-name = Barbara Shaurette
-
-[http://www.djcinnovations.com/archives/category/python/feed/atom]
-name = David J C Beach
-
-[http://www.dougalmatthews.com/feeds/python.atom.xml]
-name = Dougal Matthews
-
-[http://www.drmaciver.com/category/python/feed/]
-name = David MacIver
-
-[http://www.eflorenzano.com/blog/feeds/posts/python/]
-name = Eric Florenzano
-
-[http://www.egenix.com/company/news/rss2]
-name = eGenix.com
-
-[http://www.elastician.com/feeds/posts/default]
-name = Mitchell Garnaat
-
-[http://www.endlesslycurious.com/tag/python/feed/]
-name = Daniel Brown
-
-[http://www.europython-society.org/rss]
-name = EuroPython Society
-
-[http://www.evanfosmark.com/category/programming/python/feed]
-name = Evan Fosmark
-
-[http://www.evilchuck.com/feeds/posts/default/-/python]
-name = Chuck Thier
-
-[http://www.excelsiorsystems.net/blog/feeds/tags/Python/]
-name = Peter Halliday
-
-[http://www.firsttimeprogrammer.blogspot.com/feeds/posts/default/-/python?alt=rss]
-name = Michy Alice
-
-[http://www.flicker-technical.blogspot.fr/feeds/posts/default/-/Python]
-name = Pranav Pandey
-
-[http://www.franciscosouza.net/feeds/posts/default/-/python]
-name = Francisco Souza
-
-[http://www.fridh.nl/tag/python.atom.xml]
-name = Frederik Rietdijk
-
-[http://www.galvanize.com/blog/tag/python/feed/]
-name = Galvanize
-
-[http://www.gefira.pl/blog/tag/planet-python/feed/]
-name = Dariusz Suchojad
-
-[http://www.getlfs.com/rss/blog]
-name = Lightning Fast Shop
-
-[http://www.grodola.blogspot.com/feeds/posts/default/-/python]
-name = Giampaolo Rodola
-
-[http://www.grulic.org.ar/~mdione/glob/tags/python/index.atom]
-name = Marcos Dione
-
-[http://www.hardcoded.net/articles/rss_python.xml]
-name = Virgil Dupras
-
-[http://www.heikkitoivonen.net/blog/category/python/feed/atom/]
-name = Heikki Toivonen
-
-[http://www.hilarymason.com/tag/python/feed/]
-name = Hilary Mason
-
-[http://www.holger-peters.de/feeds/python.atom.xml]
-name = Holger Peters
-
-[http://www.huyng.com/atom.xml]
-name = Huy Nguyen
-
-[http://www.iki.fi/juri/blog/index.rss]
-name = Juri Pakaste
-
-[http://www.imankulov.name/categories/python.xml]
-name = Roman Imankulov
-
-[http://www.indelible.org/feeds/ink/python.xml]
-name = Jon Parise
-
-[http://www.iodigitalsec.com/category/python/feed/]
-name = IO Digital Sec
-
-[http://www.jasonamyers.com/feed]
-name = Jason Meyers
-
-[http://www.jeffknupp.com/blog/categories/python/atom.xml]
-name = Jeff Knupp
-
-[http://www.jodal.no/atom-python.xml]
-name = Stein Magnus Jodal
-
-[http://www.johndcook.com/blog/category/python/feed/]
-name = John Cook
-
-[http://www.johngag.com/feed/python/]
-name = John Gagliardi
-
-[http://www.jordan-dimov.com/python/atom.xml]
-name = Jordan Dimov
-
-[http://www.jrandolph.com/blog/category/python/feed/atom/]
-name = Viva La Chipperfish
-
-[http://www.juanrodriguezmonti.com.ar/tags/python/index.xml]
-name = Juan Rodríguez Monti
-
-[http://www.kennethreitz.org/?category=Development&format=rss]
-name = Kenneth Reitz
-
-[http://www.kunxi.org/tag/python/feed]
-name = Kun Xi
-
-[http://www.laurentluce.com/posts/tag/python/feed/]
-name = Laurent Luce
-
-[http://www.learningpython.com/feed/]
-name = Mark Mruss
-
-[http://www.lfcproject.com/feeds/django]
-name = Lightning Fast CMS
-
-[http://www.logarithmic.net/pfh?action=atom;hasname=1;name=gcgmgpghfpgdgpgegf]
-name = Paul Harrison
-
-[http://www.luckydonkey.com/category/python/rss]
-name = Dazza
-
-[http://www.mahdiyusuf.com/tagged/python/rss]
-name = Mahdi Yusuf
-
-[http://www.majid.info/mylos/weblog/categories/python/rss.xml]
-name = Fazal Majid
-
-[http://www.malemburg.com/rss]
-name = Marc-André Lemburg
-
-[http://www.marsja.se/category/python/feed/]
-name = Erik Marsja
-
-[http://www.mechanicalcat.net/richard/log/Python/rss]
-name = Richard Jones
-
-[http://www.metaklass.org/rss/]
-name = Jorge Niedbalski
+[http://www.pirnat.com/rss/exilejedi-python-rss.xml]
+name = Mike Pirnat
 
 [http://www.mikealrogers.com/archives/category/python/feed]
 name = Mikeal Rogers
 
-[http://www.natan.termitnjak.net/blog/category/python/feed/atom/index.xml]
-name = Natan Zabkar
+[http://kmike.ru/feeds/tags/planet-python.atom.xml]
+name = Mikhail Korobov
 
-[http://www.nicosphere.net/tag/python-en/feed/]
-name = Nicolas Paris
+[http://opensourcehacker.com/category/python/feed/]
+name = Mikko Ohtamaa
+
+[http://dmoonc.com/blog/?cat=24&feed=rss2]
+name = Mitch Chapman
+
+[http://www.elastician.com/feeds/posts/default]
+name = Mitchell Garnaat
+
+[http://pythonbyexample.blogspot.com/feeds/posts/default/]
+name = Mitya Sirenef
+
+[http://montrealpython.com/feed/]
+name = Montreal Python User Group
+
+[http://blogologue.com/atom.xml?category=1470141490X3]
+name = "Morphex's Blogologue"
 
 [http://www.nidelven-it.no/weblogs/hosting/atom.xml?category=1334244339X02]
 name = Morten W Petersen
 
+[https://www.moyaproject.com/blog/feed/]
+name = Moya Project
+
+[http://blog.mozilla.com/webdev/category/python-2/feed/]
+name = Mozilla Web Development
+
+[http://muharem.wordpress.com/feed/atom/]
+name = Muharem Hrnjadovic
+
+[http://www.thesamet.com/blog/tags/python/rss]
+name = Nadav Samet
+
+[http://nadiana.com/category/python/feed]
+name = Nadia Alramli
+
+[http://learnpython.wordpress.com/feed/atom/]
+name = Naomi Ceder
+
+[http://www.natan.termitnjak.net/blog/category/python/feed/atom/index.xml]
+name = Natan Zabkar
+
+[http://climateecology.wordpress.com/tag/python/feed/]
+name = Nathan Lemoine
+
+[https://www.neckbeardrepublic.com/rss/]
+name = Neckbeard Republic
+
+[http://nedbatchelder.com/blog/planetpython.xml]
+name = Ned Batchelder
+
+[http://python.ca/nas/log/rss-python.xml]
+name = Neil Schemenauer
+
+[http://sandbox.rulemaker.net/ngps/rdf10_python_xml]
+name = Ng Pheng Siong
+
+[http://blog.alienretro.com/category/python-en-2/feed/]
+name = Nicholas Amorim
+
+[http://nichol.as/tags/python/feed]
+name = Nicholas Piël
+
+[http://www.curiousefficiency.org/categories/python.xml]
+name = Nick Coghlan
+
+[http://www.craig-wood.com/nick/articles/category/python/feed/atom/index.xml]
+name = Nick Craig-Wood
+
+[http://blog.efford.org/tag/feeds/python.atom.xml]
+name = Nick Efford
+
+[http://nickjanetakis.blogspot.com/feeds/posts/default/-/python]
+name = Nick Janetakis
+
+[http://nicolaiarocci.com/tags/python/index.xml]
+name = Nicola Iarocci
+
+[http://nicdumz.fr/blog/category/python/feed/index.xml]
+name = Nicolas Dumazet
+
+[http://www.nicosphere.net/tag/python-en/feed/]
+name = Nicolas Paris
+
+[http://nigelb.me/python.xml]
+name = Nigel Babu
+
 [http://www.nikhilgopal.com/feeds/posts/default/-/python]
 name = Nikhil Gopal
+
+[http://feeds.feedburner.com/getnikola/QBjz]
+name = Nikola
+
+[http://artificialcode.blogspot.com/feeds/posts/default/-/python]
+name = Noah Gift
 
 [http://www.numfocus.org/1/feed]
 name = NumFOCUS
@@ -2123,59 +1587,335 @@ name = NumFOCUS
 [http://www.obeythetestinggoat.com/feeds/all.atom.xml]
 name = Obey the Testing Goat
 
+[https://andrich.blog/tag/python/feed/]
+name = Oliver Andrich
+
 [http://www.omahapython.org/blog/feed]
 name = Omaha Python Users Group
+
+[http://omar.toomuchcookies.net/node/category/programming/python/feed/]
+name = Omar Abo-Namous
+
+[http://ondrejcertik.blogspot.com/feeds/posts/default/-/python]
+name = Ond&#345;ej &#268;ert&iacute;k
+
+[http://openhatch.org/blog/tag/python/feed/atom/]
+name = OpenHatch Python posts
+
+[http://orestis.gr/feeds/tag/python/en/]
+name = Orestis Markou
+
+[http://blog.partecs.com/category/python/feed]
+name = Partecs
+
+[http://s3.amazonaws.com/blog.pathwright.com/feeds/tag.Python.atom.xml]
+name = Pathwright
+
+[http://weblog.patrice.ch/tags/Python.atom]
+name = Patrice Neff
+
+[http://pp.com.mx/blog/topics/python/feed/atom/]
+name = Patricio Paez
 
 [http://www.patricksoftwareblog.com/tag/python/feed/]
 name = Patrick Kennedy
 
-[http://www.percious.com/blog/?feed=rss2&cat=3]
-name = Christopher Perkins
+[http://pkaudio.blogspot.com/feeds/posts/default/-/python]
+name = Patrick Stinson
+
+[http://news.e-scribe.com/feeds/tag/python/atom.xml]
+name = Paul Bissex
+
+[http://pauleveritt.wordpress.com/feed/atom/]
+name = Paul Everitt
+
+[http://www.logarithmic.net/pfh?action=atom;hasname=1;name=gcgmgpghfpgdgpgegf]
+name = Paul Harrison
+
+[http://codebright.wordpress.com/category/python/feed/atom/]
+name = Paul Redman
+
+[http://python.genedrift.org/feed/]
+name = Paulo Nuin
+
+[http://pfertyk.me/feeds/python.atom.xml]
+name = Paweł Fertyk
+
+[https://www.paypal-engineering.com/tag/python/feed/]
+name = PayPal Engineering Blog
+
+[http://pedrokroger.net/category/python/feed/]
+name = Pedro Kroger
+
+[http://pedro.valelima.com/blog/feed/tag/python/]
+name = Pedro Lima
 
 [http://www.petehunt.net/blog/?feed=rss2]
 name = Pete Hunt
 
+[https://wearpants.org/feeds/petecode.xml?tag=python]
+name = Petecode
+
 [http://www.peterbe.com/oc-Python/rss.xml]
 name = Peter Bengtsson
+
+[http://petereisentraut.blogspot.com/feeds/posts/default/-/Python/]
+name = Peter Eisentraut
+
+[http://neovox.advancedmagic.de/?feed=rss2&cat=6]
+name = Peter Fankhänel
+
+[http://www.excelsiorsystems.net/blog/feeds/tags/Python/]
+name = Peter Halliday
+
+[http://push.cx/tag/python/feed]
+name = Peter Harkins
+
+[http://peter-hoffmann.com/feed/atom-python.xml]
+name = Peter Hoffmann
+
+[http://mindtrove.info/tag/python/feed/index.xml]
+name = Peter Parente
+
+[http://petro.tanrei.ca/categories/python/feed.atom]
+name = Petro Verkhogliad
 
 [http://www.philhassey.com/blog/category/python/feed]
 name = Phil Hassey
 
-[http://www.pirnat.com/rss/exilejedi-python-rss.xml]
-name = Mike Pirnat
+[http://dunderboss.blogspot.com/feeds/posts/default/-/python]
+name = Philip Jenvey
 
-[http://www.protocolostomy.com/category/python/feed/]
-name = Brian Jones
+[http://blog.pyspoken.com/feed/atom/]
+name = Philip Semanchuk
 
-[http://www.protocolostomy.com/category/technology/python/feed]
-name = Brian Jones
+[http://philikon.wordpress.com/category/python/feed/atom/]
+name = Philipp von Weitershausen
 
-[http://www.pyptug.org/feeds/posts/default/]
-name = Python Piedmont Triad User Group
+[http://base-art.net/Articles/rss.xml]
+name = Philippe Normand
 
-[http://www.python-blog.com/feed/atom/]
-name = Marcin Kuźmiński
+[http://feeds.feedburner.com/pje-on-programming]
+name = Phillip J. Eby
 
-[http://www.python.org/channews.rdf]
-name = Python News
+[http://sites.google.com/site/pydatalog/pypl/python-blog/posts.xml]
+name = Pierre Carbonnelle
+
+[http://mancoosi.org/~abate/taxonomy/term/56/0/feed]
+name = Pietro Abate
+
+[https://www.podcastinit.com/feed/mp3/]
+name = Podcast.__init__
+
+[https://ironboundsoftware.com/blog/category/python/feed/]
+name = Possbility and Probability
+
+[http://feeds.feedburner.com/btbytes_python]
+name = Pradeep Gowda
+
+[http://www.flicker-technical.blogspot.fr/feeds/posts/default/-/Python]
+name = Pranav Pandey
+
+[http://feeds.feedburner.com/shutupandship_python]
+name = Praveen Gollakota
+
+[http://programandociencia.com/category/english/feed/]
+name = Programando Ciência
+
+[https://www.programiz.com/python-programming/rss.xml]
+name = Programiz
+
+[https://programmingideaswithjake.wordpress.com/category/python/feed/]
+name = Programming Ideas With Jake
+
+[https://eshlox.net/tag/python/rss/index.xml]
+name = Przemysław Kołodziejczyk
+
+[http://blog.pyamf.org/feed]
+name = PyAMF Blog
+
+[http://pybit.es/feeds/all.rss.xml]
+name = PyBites
+
+[http://blog.pycarolinas.org/rss/]
+name = PyCarolinas
+
+[http://feeds.feedburner.com/Pycharm]
+name = PyCharm
+
+[http://feeds.feedburner.com/PyCon]
+name = PyCon
+
+[http://www.youtube.com/rss/user/pycon08/videos.rss]
+name = PyCon 2008 on YouTube
+
+[https://2016.pycon-au.org/media/news/rss]
+name = PyCon Australia
+
+[http://pl.pycon.org/2015/en/rss-aktualnosci]
+name = PyCon PL Conference
+
+[http://advocacy.python.org/podcasts/pycon.rss]
+name = PyCon Podcast
+
+[http://pyladies.com/blog/feeds/atom/]
+name = PyLadies
+
+[http://morepypy.blogspot.com/feeds/posts/default]
+name = PyPy Development
+
+[http://pytennessee.tumblr.com/rss]
+name = PyTennessee
+
+[https://www.pytexas.org/blog.rss]
+name = PyTexas
+
+[http://pylonshq.com/articles.atom]
+name = Pylons News Feed
+
+[http://feeds.feedburner.com/pypix]
+name = Pypix
+
+[http://python4kids.wordpress.com/feed/atom/]
+name = Python 4 Kids
+
+[http://www.awaretek.com/python/index.xml]
+name = Python 411 Podcast
+
+[http://python-advocacy.blogspot.com/atom.xml]
+name = Python Advocacy
+
+[http://blog.pythonanywhere.com/feed/]
+name = Python Anywhere
+
+[https://pythonbytes.fm/episodes/rss]
+name = Python Bytes
+
+[http://pythondata.com/feed/]
+name = Python Data
 
 [http://www.pythondiary.com/blog.xml]
 name = Python Diary
 
+[http://pythondoeswhat.blogspot.com/feeds/posts/default]
+name = Python Does What?!
+
+[https://blogs.msdn.microsoft.com/pythonengineering/feed/]
+name = Python Engineering at Microsoft
+
+[http://feeds.feedburner.com/PythonInsider]
+name = Python Insider
+
+[http://www.python.org/channews.rdf]
+name = Python News
+
+[http://python-open-mike.posterous.com/rss.xml]
+name = Python Open Mike
+
+[http://www.pyptug.org/feeds/posts/default/]
+name = Python Piedmont Triad User Group
+
+[http://pyfound.blogspot.com/atom.xml]
+name = Python Software Foundation
+
+[http://pythonsprints.com/feeds/latest/]
+name = Python Sprints
+
+[http://pythonsweetness.tumblr.com/rss]
+name = Python Sweetness
+
+[http://pythontestingcookbook.posterous.com/rss.xml]
+name = Python Testing Cookbook
+
+[http://python-groups.blogspot.com/feeds/posts/default]
+name = Python User Groups
+
+[http://pythonforbiologists.com/index.php/category/python/feed/]
+name = Python for biologists
+
+[http://python-karan.blogspot.in//feeds/posts/default]
+name = Python on Karan
+
+[http://developerblog.myo.com/tag/python/rss/]
+name = Python with Myo
+
+[http://pythonxynews.blogspot.com/feeds/posts/default]
+name = Python(x,y) News
+
+[http://pythonclub.com.br/feeds/all.atom.xml]
+name = PythonClub - A Brazilian collaborative blog about Python
+
 [http://www.pythonthreads.com/index2.php?option=com_rss&feed=RSS2.0&no_html=1]
 name = PythonThreads
 
-[http://www.pythonwise.blogspot.com/feeds/posts/default/-/python]
-name = pythonwise
+[http://pythonology.blogspot.com/atom.xml]
+name = Pythonology
+
+[http://ptspts.blogspot.com/feeds/posts/default/-/planet-python]
+name = Péter Szabó
+
+[http://blog.zsoldosp.eu/category/python/feed/]
+name = Péter Zsoldos
+
+[http://www.bitdance.com/blog/rss.xml]
+name = R David Murray
+
+[http://threebean.org/blog/category/python/feed/atom/index.xml]
+name = Ralph Bean
 
 [http://www.ralph-heinkel.com/blog/category/python/feed/atom/index.xml]
 name = Ralph Heinkel
 
-[http://www.redesigndavid.com/atom?&tags=python]
-name = David Marte
+[http://feeds.feedburner.com/RamRachumsBlog/planetpython]
+name = Ram Rachum
 
-[http://www.redmountainsw.com/wordpress/archives/category/python/feed/atom]
-name = Chui Tey
+[http://blog.sramana.in/rss.xml?tag=python]
+name = Ramana
+
+[http://blog.randell.ph/tag/python/feed/atom/]
+name = Randell Benavidez
+
+[http://randlet.com/blog/python/rss.xml]
+name = Randle Taylor
+
+[http://randyzwitch.com/tag/python/feed/]
+name = Randy Zwitch
+
+[http://rhettinger.wordpress.com/feed/atom/]
+name = Raymond Hettinger
+
+[http://rayli.net/blog/tag/planetpython/feed/]
+name = Raymond Li
+
+[http://reachtim.com/feeds/python.atom.xml]
+name = Reach Tim
+
+[https://realpython.com/atom.xml]
+name = Real Python
+
+[http://reinout.vanrees.org/weblog/plonefeed.xml]
+name = Reinout van Rees
+
+[http://renesd.blogspot.com/feeds/posts/default/-/python]
+name = Rene Dudfield
+
+[http://blog.lerner.co.il/category/python/feed/]
+name = Reuven Lerner
+
+[http://rgomes-info.blogspot.co.uk/feeds/posts/default/-/python]
+name = Richard Gomes
+
+[http://www.mechanicalcat.net/richard/log/Python/rss]
+name = Richard Jones
+
+[http://posted-stuff.blogspot.com/feeds/posts/default/-/python]
+name = Richard Tew
+
+[http://blog.the-moon.net/feeds/posts/default/-/python]
+name = Richard Wall
+
+[http://blog.cakebread.info/feeds/posts/default/-/python]
+name = Rob Cakebread
 
 [http://www.robg3d.com/?tag=python&feed=atom]
 name = Rob Galanakis
@@ -2183,92 +1923,401 @@ name = Rob Galanakis
 [http://www.robgolding.com/feed/?tag=python]
 name = Rob Golding
 
-[http://www.sauria.com/blog/category/programming-languages/python/feed/atom/]
-name = Ted Leung
+[http://blog.nonsequitarian.org/feeds/tags/planetpython/]
+name = Rob Miller
 
-[http://www.sdjournal.com/archives/categories/languages/python/rss.xml]
-name = SDJournal
+[http://www.aminus.org/blogs/xmlsrv/rss2.php?blog=2&cat=15]
+name = Robert Brewer
 
-[http://www.serverzen.net/feeds/posts/default/-/python]
-name = Rocky Burt
+[http://rbtcollins.wordpress.com/tag/python/feed/atom/]
+name = Robert Collins
 
-[http://www.shisaa.jp/categories/python.xml]
-name = Tim van der Linden
+[http://robert-lujo.com/tagged/python/rss]
+name = Robert Lujo
 
-[http://www.snowboardingcoder.com/django/?feed=rss2]
-name = Experienced Django
+[http://robert.io/blog/categories/python/atom.xml]
+name = Robert Picard
 
-[http://www.softformance.com/feed/?tag=python]
-name = SoftFormance
+[http://rz.scale-it.pl/rss-python.html]
+name = Robert Zaremba
 
-[http://www.stealthcopter.com/blog/tag/python/feed/]
-name = Matthew Rollings
+[http://feeds.feedburner.com/LateralOpinionpython]
+name = Roberto Alsina
 
-[http://www.super-cooper.com/archive/category/python/feed]
-name = Chad Cooper
-
-[http://www.sys-exit.blogspot.com/feeds/posts/default/-/python]
-name = Tomasz Ducin
-
-[http://www.szotten.com/david/feeds/python.atom.xml]
-name = David Szotten
-
-[http://www.talaikis.com/python/feed/]
-name = Investing using Python
-
-[http://www.talkpythontome.com/episodes/rss]
-name = Talk Python to Me
-
-[http://www.tartley.com/?feed=rss2&cat=10]
-name = Jonathan Hartley
-
-[http://www.teachmepython.com/feed/]
-name = Teach Me Python
-
-[http://www.tech-foo.net/feeds/tag-python.atom.xml]
-name = Thomi Richards
-
-[http://www.technobabble.dk/feeds/tags/python/]
-name = Christian Joergensen
+[http://wxPython.org/blog/feed/]
+name = Robin Dunn
 
 [http://www.theatreofnoise.com/feeds/posts/default/-/dev]
 name = Robin Parmar
 
-[http://www.thedatascientist.de/category/python/feed/]
-name = The Data Scientist
+[http://blog.rtwilson.com/category/programming-2/python/feed/]
+name = Robin Wilson
 
-[http://www.themacaque.com/?tag=python&feed=rss2]
-name = Manuel de la Pena Saenz
+[http://www.upfrontsystems.co.za/Members/roche/where-im-calling-from/RSS]
+name = Roche Compaan
 
-[http://www.thesamet.com/blog/tags/python/rss]
-name = Nadav Samet
+[http://www.serverzen.net/feeds/posts/default/-/python]
+name = Rocky Burt
 
-[http://www.tibonihoo.net/blog/en/tag/python/feed/]
-name = Thibauld Nion
+[http://linil.wordpress.com/feed/atom/]
+name = Rodrigo Araúj
 
-[http://www.tomaz.me/tags/python.xml]
-name = Tomaž Muraus
+[http://garbas.si/blog/category/latest-python/RSS]
+name = Rok Garbas
 
-[http://www.toolness.com/wp/?cat=11&feed=rss2]
-name = Atul Varma -- Toolness
+[http://www.imankulov.name/categories/python.xml]
+name = Roman Imankulov
 
-[http://www.traceback.org/category/python/feed]
-name = David Stanek
+[https://www.rosehosting.com/blog/tag/python/feed/]
+name = RoseHosting Blog
 
-[http://www.tryton.org/rss.xml]
-name = Tryton News
+[http://ruslanspivak.com/category/python/feed/atom/]
+name = Ruslan Spivak
+
+[http://www.asciiarmor.com/tagged/python/rss]
+name = Ryan Cox
+
+[http://naeblis.cx/rtomayko/weblog/python/index.rdf]
+name = Ryan Tomayko
+
+[http://slott-softwarearchitect.blogspot.com/feeds/posts/default/-/python]
+name = S. Lott
+
+[https://pyhelper.wordpress.com/feed/]
+name = S. R. Krishnan
+
+[http://www.sdjournal.com/archives/categories/languages/python/rss.xml]
+name = SDJournal
+
+[http://pythonide.blogspot.com/feeds/posts/default]
+name = SPE Weblog
+
+[http://blog.stxnext.com/feeds/python.atom.xml]
+name = STX Next
+
+[http://feeds.feedburner.com/sfpy]
+name = Salim Fadhley
+
+[http://bitshaq.com/tag/python/feed/atom/]
+name = Salman Haq
+
+[http://ssutch.org/tag/python/feed]
+name = Samuel Sutch
+
+[https://sandipanweb.wordpress.com/category/python/feed/]
+name = Sandipan Dey
+
+[http://sandrotosi.blogspot.com/feeds/posts/default/-/Python]
+name = Sandro Tosi
+
+[https://sayanchowdhury.dgplug.org/tags/planet/]
+name = Sayan Chowdhury
+
+[http://python.scripting.com/xml/rss.xml]
+name = Scripting the web with Python
+
+[http://seanmcgrath.blogspot.com/feeds/posts/default/-/python]
+name = Sean McGrath
 
 [http://www.tummy.com/journals/users/jafo/rss-python.xml]
 name = Sean Reifschneider
 
+[http://www.chesnok.com/daily/category/python/feed/]
+name = Selena Deckelmann
+
+[https://semaphoreci.com/community/tags/python.atom]
+name = Semaphore Community
+
+[http://feeds.feedburner.com/phoe6pythonfeeds]
+name = Senthil Kumaran
+
+[http://blog.serverdensity.com/category/python/feed/]
+name = Server Density
+
+[http://jjinux.blogspot.com/feeds/posts/default/-/python]
+name = Shannon -jj Behrens
+
+[http://shiningpanda.com/feeds/all.atom.xml]
+name = ShiningPanda
+
+[http://shriphani.com/blog/category/python/feed]
+name = Shriphani Palakodety
+
+[http://simeonfranklin.com/feeds/python/]
+name = Simeon Franklin
+
+[http://feeds.feedburner.com/simeon_visser_python]
+name = Simeon Visser
+
+[http://aboutsimon.com/category/python/feed/atom/]
+name = Simon
+
+[http://www.brunningonline.net/simon/blog/index-P.xml]
+name = Simon Brunning
+
+[http://simonwillison.net/atom/tagged/python/]
+name = Simon Willison
+
+[http://entitycrisis.blogspot.com/feeds/posts/default/-/Python]
+name = Simon Wittber
+
+[https://simpleisbetterthancomplex.com/feed.xml]
+name = Simple is Better Than Complex
+
+[http://www.softformance.com/feed/?tag=python]
+name = SoftFormance
+
+[http://speno.blogspot.com/atom.xml]
+name = "Speno's Pythonic Avocado"
+
+[http://spikeekips.tumblr.com/tagged/python/rss]
+name = Spike ekipS
+
+[http://spyder-ide.blogspot.com/feeds/posts/default]
+name = Spyder IDE
+
+[http://westmarch.sjsoft.com/tag/python/feed/]
+name = St James Software Development
+
+[http://stackabuse.com/tag/python/rss]
+name = Stack Abuse
+
+[http://stacks.11craft.com/feeds/tag.python.atom.xml]
+name = Stacks
+
+[https://www.starzel.de/blog/starzel-de-python-blog/RSS]
+name = Starzel.de
+
+[http://blog.behnel.de/index.php?feed=rss2&cat=22]
+name = Stefan Behnel
+
+[http://blog.garage-coding.com/tag/python/feed.xml]
+name = Stefan Petrea
+
+[http://stefan.sofa-rockers.org/feeds/python]
+name = Stefan Scherfke
+
+[http://www.jodal.no/atom-python.xml]
+name = Stein Magnus Jodal
+
+[http://pythonconquerstheuniverse.wordpress.com/feed/atom/]
+name = Stephen Ferg
+
+[http://stevedower.id.au/blog/category/python/feed/]
+name = Steve Dower
+
+[http://holdenweb.blogspot.com/feeds/posts/default/-/python]
+name = Steve Holden
+
+[http://rh0dium.blogspot.com/feeds/posts/default/-/python]
+name = Steven Klass
+
+[http://blog.lost-theory.org/tags/python/feed.atom]
+name = Steven Kryskalla
+
+[http://www.devpicayune.com/category/python/feed]
+name = Steven Wilcox
+
+[http://stdout.be/tag/django/feed/]
+name = Stijn Debrouwere
+
+[https://storiesinmypocket.com/feed/python/]
+name = Stories in My Pocket
+
+[http://TuringFinance.com/category/python/feed/]
+name = Stuart Gordon Reid
+
+[http://wirtel.be/tags/python/index.xml]
+name = Stéphane Wirtel
+
+[http://sumith1896.github.io/feeds/feed.sympy.xml]
+name = Sumith - Blog about SymPy/Python
+
+[http://swaroopch.com/tag/python/feed/]
+name = Swaroop C H
+
+[http://swiftstack.com/blog/python.xml]
+name = SwiftStack
+
+[http://ict.swisscom.ch/tag/python/feed]
+name = Swisscom ICT
+
+[http://www.defuze.org/archives/category/python/feed]
+name = Sylvain Hellegouarch
+
+[http://www.talkpythontome.com/episodes/rss]
+name = Talk Python to Me
+
+[http://blog.ziade.org/tag/python/feed]
+name = Tarek Ziade
+
+[http://blog.tedmiston.com/tag/python/rss]
+name = Taylor Edmiston
+
+[http://www.teachmepython.com/feed/]
+name = Teach Me Python
+
+[https://www.techiediaries.com/django/feed.xml]
+name = Techiediaries - Django
+
+[http://www.sauria.com/blog/category/programming-languages/python/feed/atom/]
+name = Ted Leung
+
+[http://philosophyofweb.com/category/python/feed/]
+name = Ted Nyman
+
+[http://blog.teemu.im/tags/python/feed/]
+name = Teemu Harju
+
+[http://myownhat.blogspot.com/feeds/posts/default/-/python]
+name = Tennessee Leeuwenburg
+
+[http://terriko.dreamwidth.org/data/rss?tag=python]
+name = Terri Oda
+
+[http://blogs.fluidinfo.com/terry/category/python/feed/atom/]
+name = Terry Jones
+
+[http://swordstyle.com/blog2/?feed=rss2&cat=20]
+name = Terry Peppers
+
+[http://blog.aicookbook.com/category/python/feed/atom/]
+name = The Artificial Intelligence Cookbook
+
+[http://thechangelog.com/tagged/python/rss]
+name = The Changelog
+
+[http://www.thedatascientist.de/category/python/feed/]
+name = The Data Scientist
+
+[http://blog.thedigitalcatonline.com/categories/python/atom.xml]
+name = The Digital Cat
+
+[http://blog.dowski.com/category/python/feed]
+name = The Occasional Occurrence
+
+[http://blog.parcon.opengroove.org/feeds/posts/default]
+name = The Parcon Blog
+
+[http://pythonpapers.blogspot.com/atom.xml]
+name = The Python Papers
+
+[http://avelino.xxx/python-en/feed]
+name = Thiago Avelino
+
+[http://www.tibonihoo.net/blog/en/tag/python/feed/]
+name = Thibauld Nion
+
+[http://ballingt.com/feed.python.xml]
+name = "Thomas Ballinger's Blog"
+
+[http://feeds.wordaligned.org/wordaligned/python]
+name = Thomas Guest
+
+[http://thomas.apestaart.org/log/?feed=rss2&cat=22]
+name = Thomas Vander Stichele
+
+[http://www.tech-foo.net/feeds/tag-python.atom.xml]
+name = Thomi Richards
+
+[https://www.tibobeijen.nl/tags/python/index.xml]
+name = Tibo Beijen
+
+[http://timgilbert.wordpress.com/category/python/feed/atom/]
+name = Tim Gilbert
+
+[http://ramblings.timgolden.me.uk/category/tech/python/feed/]
+name = Tim Golden
+
+[http://feeds.feedburner.com/duffyd]
+name = Tim Knapp
+
+[http://apipes.blogspot.com/feeds/posts/default/-/python]
+name = Tim Lesher
+
+[http://dev.timparkin.co.uk/feeds/posts/default?alt=rss]
+name = Tim Parkin
+
+[http://www.shisaa.jp/categories/python.xml]
+name = Tim van der Linden
+
+[http://ivory.idyll.org/blog/tags/python?flav=atom]
+name = Titus Brown
+
+[http://feeds.feedburner.com/thobe/wardrobe]
+name = Tobias Ivarsson
+
+[http://thewebhaswon.wordpress.com/category/python/atom]
+name = Tom Christie
+
+[http://www.sys-exit.blogspot.com/feeds/posts/default/-/python]
+name = Tomasz Ducin
+
+[http://pragmaticpython.com/feed/?tag=python]
+name = Tomasz Früboes
+
+[http://www.tomaz.me/tags/python.xml]
+name = Tomaž Muraus
+
+[http://tomerfiliba.com/blog/python-atom.xml]
+name = Tomer Filiba
+
+[http://tonybreyal.wordpress.com/category/python/feed/atom/]
+name = Tony Breyal
+
+[http://better-inter.net/rss/python/]
+name = Torsten Engelbrecht
+
+[http://anonbadger.wordpress.com/tag/python/feed/atom/]
+name = Toshio Kuratomi
+
+[http://technicaldiscovery.blogspot.com/feeds/posts/default/-/python]
+name = Travis Oliphant
+
+[http://treyhunner.com/python.xml]
+name = Trey Hunner
+
+[http://blog.melhase.net/xml/rss20/feed.xml]
+name = Troy Melhase
+
+[http://www.tryton.org/rss.xml]
+name = Tryton News
+
 [http://www.turnkeylinux.org/taxonomy/term/103/0/feed]
 name = Turnkey Linux
 
-[http://www.unquietdesperation.com/category/python/feed]
-name = Chris Miller
+[http://feeds.feedburner.com/TwistedMatrixLaboratories]
+name = Twisted Matrix Labs
 
-[http://www.upfrontsystems.co.za/Members/roche/where-im-calling-from/RSS]
-name = Roche Compaan
+[http://copia.posterous.com/rss.xml?tag=python]
+name = Uche Ogbuji
+
+[http://united-coders.com/taxonomy/term/22/0/feed]
+name = United Coders
+
+[http://vsbabu.org/mt/index.rdf]
+name = V.S. Babu
+
+[http://prayogshala.wordpress.com/category/scripting/python/feed/atom/]
+name = Varun Nischal
+
+[http://jugad2.blogspot.co.uk/feeds/posts/default/-/python]
+name = Vasudev Ram
+
+[http://pymolurus.blogspot.com/feeds/posts/default]
+name = Vinay Sajip
+
+[http://plumberjack.blogspot.com/feeds/posts/default]
+name = Vinay Sajip (Logging)
+
+[http://www.hardcoded.net/articles/rss_python.xml]
+name = Virgil Dupras
+
+[http://www.jrandolph.com/blog/category/python/feed/atom/]
+name = Viva La Chipperfish
+
+[https://nvbn.github.io/feed.python.xml]
+name = Vladimir Iakolev
 
 [http://www.vperic.blogspot.com/feeds/posts/default/-/Twisted]
 name = Vladimir Perić
@@ -2276,210 +2325,144 @@ name = Vladimir Perić
 [http://www.wallix.org/tag/python/feed/atom/]
 name = Wallix
 
+[http://www.djangotimes.com/feeds/posts/all/]
+name = Washington Times OpenSource
+
+[http://pieceofpy.com/category/python/feed/atom/index.xml]
+name = Wayne Witzel
+
 [http://www.weeklypython.chat/feed/]
 name = Weekly Python Chat
 
-[http://www.wefearchange.org/feeds/posts/default]
-name = Barry Warsaw
+[http://python-weekly.blogspot.com/feeds/posts/default?alt=rss]
+name = Weekly Python StackOverflow Report
+
+[http://1stvamp.org/tag/python/atom/]
+name = Wes Mason
+
+[http://wescpy.blogspot.com/feeds/posts/default/-/python]
+name = Wesley Chun
 
 [http://www.wiggy.net/atom.python.xml]
 name = Wichert Akkerman
 
+[http://bluesock.org/~willkg/blog/tag/python.xml]
+name = Will Kahn-Greene
+
 [http://www.willmcgugan.com/blog/tech/feeds/posts/]
 name = Will McGugan
 
-[http://www.wisdomandwonder.com/tag/python/feed]
-name = Grant Rettke
+[http://willpython.blogspot.com/feeds/posts/default]
+name = Will Pierce
+
+[http://blog.minchin.ca/feeds/label.python.atom.xml]
+name = William Minchin
+
+[http://foolish-assertions.blogspot.com/feeds/posts/default/-/python]
+name = William Reade
+
+[http://dietbuddha.blogspot.com/feeds/posts/default/-/python]
+name = William Thompson
+
+[http://william-os4y.livejournal.com/data/atom]
+name = "William's Journal"
+
+[http://wingware.com/blog/rss&noheader=1]
+name = Wingware Blog
+
+[http://wingware.com/news/rss&noheader=1]
+name = Wingware News
+
+[http://wolfram.kriesing.de/blog/index.php/category/programming/python/feed]
+name = Wolfram Kriesing
+
+[http://blog.wraithan.net/tag/python/feed/]
+name = Wraithan
+
+[http://blog.wyattbaldwin.com/feed/planet-python/atom.xml]
+name = Wyatt Baldwin
+
+[http://blog.madpython.com/tag/python/feed/atom/]
+name = Xavier Spriet
 
 [http://www.yaco.es/blog/en/tag/python-en/feed/]
 name = Yaco
 
+[http://tech.blog.aknin.name/tag/python/feed/atom/]
+name = Yaniv Aknin
+
 [http://www.ylarrivee.com/tag/python/feed/]
 name = Yann Larrivée
-
-[http://www.youtube.com/rss/user/pycon08/videos.rss]
-name = PyCon 2008 on YouTube
-
-[http://wxPython.org/blog/feed/]
-name = Robin Dunn
-
-[http://xthought.org/feeds/latest/category/python/]
-name = Ashley Camba
-
-[http://yeoldeclue.com/cgi-bin/blog/food.cgi]
-name = Michael Sparks
 
 [http://ygingras.net/b/feed/python]
 name = Yannick Gingras
 
+[http://freepythontips.wordpress.com/feed/atom]
+name = Yasoob Khalid
+
+[https://yoongkang.com/feeds/all.atom.xml]
+name = Yoong Kang Lim
+
+[http://uberpython.wordpress.com/tag/python/feed/atom/]
+name = Yuval Greenfield
+
+[http://blog.zacharyvoase.com/tagged/python/rss]
+name = Zachary Voase
+
 [http://za.github.io/feed.python.xml]
 name = Zaki Akhmad
 
-[http://zebert.blogspot.com/feeds/posts/default/-/python]
-name = Bertrand Mathieu
-
-[http://zombofant.net/blog/tags/python?feed=atom]
-name = zombofant.net
-
-[http://zyasoft.com/pythoneering/atom.xml]
-name = Jim Baker
-
-[https://2016.pycon-au.org/media/news/rss]
-name = PyCon Australia
-
-[https://alexmorozov.github.io/feeds/tag-python.atom.xml]
-name = Alex Morozov
-
-[https://anarc.at/tag/python-planet/index.rss]
-name = Anarcat
-
-[https://andrich.blog/tag/python/feed/]
-name = Oliver Andrich
-
-[https://anweshadas.in/tag/python/rss/]
-name = Anwesha Das
-
-[https://blog.ionelmc.ro/feeds/python.atom.xml]
-name = Ionel Cristian Mărieș
-
-[https://blogs.msdn.microsoft.com/pythonengineering/feed/]
-name = Python Engineering at Microsoft
-
-[https://bultrowicz.com/blog/tag/python/atom.xml]
-name = Michał Bultrowicz
-
-[https://cito.github.io/tags/python/index.xml]
-name = Christoph Zwerschke
-
-[https://clusterhq.com/feed.python.xml]
-name = ClusterHQ
-
-[https://cobe.io/blog/categories/python.xml]
-name = Cobe.io
-
-[https://emptysqua.re/blog/category/python/index.xml]
-name = A. Jesse Jiryu Davis
-
-[https://eshlox.net/tag/python/rss/index.xml]
-name = Przemysław Kołodziejczyk
-
-[https://examachine.net/blog/category/python/feed/]
-name = Eray Özkural (examachine)
-
-[https://godjango.com/rss/main/]
-name = GoDjango
-
-[https://hynek.me/feed-python.xml]
-name = Hynek Schlawack
-
-[https://ironboundsoftware.com/blog/category/python/feed/]
-name = Possbility and Probability
-
-[https://janusworx.com/tag/python/rss]
-name = Janusworx
-
-[https://koodaamo.wordpress.com/category/python/feed]
-name = Koodaamo
-
-[https://maltheborch.com/rss?tags=python]
-name = Malthe Borch
+[http://blogfeed.zato.io/blog/categories/planet-python.xml]
+name = Zato Blog
 
 [https://medium.com/feed/@ZeroDB_]
 name = ZeroDB
 
+[http://commandline.org.uk/feeds/full/python/]
+name = Zeth
+
+[http://blog.bottlepy.org/feeds/all.atom.xml]
+name = bottlepy-dev
+
+[http://feeds.feedburner.com/codeboje_python]
+name = codeboje
+
+[http://www.egenix.com/company/news/rss2]
+name = eGenix.com
+
+[http://hypothesis.works/articles/python/feed/]
+name = hypothesis.works articles
+
+[http://scummos.blogspot.com/feeds/posts/default/-/kdev-python]
+name = kdev-python
+
+[http://nl-project.blogspot.com/feeds/posts/default/-/python]
+name = nl-project
+
+[http://pgcli.com/feeds/tag.python.atom.xml]
+name = pgcli
+
+[http://www.pythonwise.blogspot.com/feeds/posts/default/-/python]
+name = pythonwise
+
+[http://blog.qutebrowser.org/feeds/tag-pyplanet.rss.xml]
+name = qutebrowser development blog
+
 [https://medium.com/feed/@tryexceptpass]
 name = tryexceptpass
 
-[https://nerandell.github.io/atom.xml]
-name = Ankit Chandawala
+[http://radar.wiredobjects.eu/category/python/feed/]
+name = wiredobjects
 
-[https://ntguardian.wordpress.com/category/python/feed/]
-name = Curtis Miller
+[http://zombofant.net/blog/tags/python?feed=atom]
+name = zombofant.net
 
-[https://nvbn.github.io/feed.python.xml]
-name = Vladimir Iakolev
+[http://wokslog.wordpress.com/tag/python/feed/atom/]
+name = Éric Araujo
 
-[https://programmingideaswithjake.wordpress.com/category/python/feed/]
-name = Programming Ideas With Jake
+[http://lukasz.langa.pl/feed/tag/python/rss-en.xml]
+name = Łukasz Langa
 
-[https://pyhelper.wordpress.com/feed/]
-name = S. R. Krishnan
-
-[https://pythonbytes.fm/episodes/rss]
-name = Python Bytes
-
-[https://realpython.com/atom.xml]
-name = Real Python
-
-[https://sandipanweb.wordpress.com/category/python/feed/]
-name = Sandipan Dey
-
-[https://sayanchowdhury.dgplug.org/tags/planet/]
-name = Sayan Chowdhury
-
-[https://semaphoreci.com/community/tags/python.atom]
-name = Semaphore Community
-
-[https://simpleisbetterthancomplex.com/feed.xml]
-name = Simple is Better Than Complex
-
-[https://snarky.ca/rss/]
-name = Brett Cannon
-
-[https://storiesinmypocket.com/feed/python/]
-name = Stories in My Pocket
-
-[https://tech.blue-yonder.com/tag/python/feed/]
-name = Blue Yonder Tech
-
-[https://wearpants.org/feeds/petecode.xml?tag=python]
-name = Petecode
-
-[https://www.codementor.io/python/tutorial/feed/]
-name = Codementor
-
-[https://www.datacamp.com/community/blog/python-feed.rss]
-name = DataCamp
-
-[https://www.dataquest.io/blog/tag/python/index.xml]
-name = Dataquest
-
-[https://www.fullstackpython.com/feeds/all.atom.xml]
-name = Full Stack Python
-
-[https://www.moyaproject.com/blog/feed/]
-name = Moya Project
-
-[https://www.neckbeardrepublic.com/rss/]
-name = Neckbeard Republic
-
-[https://www.paypal-engineering.com/tag/python/feed/]
-name = PayPal Engineering Blog
-
-[https://www.podcastinit.com/feed/mp3/]
-name = Podcast.__init__
-
-[https://www.programiz.com/python-programming/rss.xml]
-name = Programiz
-
-[https://www.pydanny.com/feeds/python.atom.xml]
-name = Daniel Roy Greenfeld
-
-[https://www.pytexas.org/blog.rss]
-name = PyTexas
-
-[https://www.rosehosting.com/blog/tag/python/feed/]
-name = RoseHosting Blog
-
-[https://www.starzel.de/blog/starzel-de-python-blog/RSS]
-name = Starzel.de
-
-[https://www.techiediaries.com/django/feed.xml]
-name = Techiediaries - Django
-
-[https://www.tibobeijen.nl/tags/python/index.xml]
-name = Tibo Beijen
-
-[https://yoongkang.com/feeds/all.atom.xml]
-name = Yoong Kang Lim
+[http://pyarab.blogspot.se/atom.xml]
+name = بايثون العربي
 

--- a/config/sort-ini.py
+++ b/config/sort-ini.py
@@ -23,12 +23,26 @@ def write():
             fd.write("%s = %s\n" % (key, str(value).replace('\n', '\n\t')))
         fd.write("\n")
     
+    result = {}
     for section in sorted(oconfig._sections):
-        fd.write("[%s]\n" % section)
+        if section == 'Planet':
+            fd.write("[%s]\n" % section)
         for (key, value) in oconfig._sections[section].items():
             if key != "__name__":
-                fd.write("%s = %s\n" %
+                if section == 'Planet':
+                    fd.write("%s = %s\n" %
                          (key, str(value).replace('\n', '\n\t')))
+                else:
+                    result[value.replace('"', '')] = section
+        if section == 'Planet':
+            fd.write("\n")
+    
+    for key, value in sorted(result.items()):
+        fd.write("[%s]\n" % value)
+        name = key
+        if "'" in key:
+            name = '"%s"' % key
+        fd.write("name = %s\n" % name)
         fd.write("\n")
 
 write()


### PR DESCRIPTION
Fix #128 

`pythyon sort-ini.py` will now sort entries by `name` tag instead of the blog URL