### PR TITLE
Add Python tag on the shopkick tech blog

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -2043,6 +2043,9 @@ name = Shannon -jj Behrens
 [http://shiningpanda.com/feeds/all.atom.xml]
 name = ShiningPanda
 
+[https://tech.shopkick.com/tagged/python/atom.xml]
+name = Shopkick Tech Blog
+
 [http://shriphani.com/blog/category/python/feed]
 name = Shriphani Palakodety
 


### PR DESCRIPTION
# ADD FEED
-------------------------------------------------------------------------------

Hi, I want to add the shopkick tech blog's feed for its Python tag to the Python Planet.

## I checked the following required validations:

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=MY_FEED_URL and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)

Thanks in advance for adding my feed to the PythonPlanet! :+1: :+1: :+1: :+1: :+1: 🎉 
