### PR TITLE
Suppress CodeMentor feed

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -423,9 +423,6 @@ name = Cobe.io
 [http://codesnipers.com/?q=taxonomy/term/16/0/feed]
 name = CodeSnipers
 
-[https://www.codementor.io/community/topic/python/feed]
-name = Codementor
-
 [http://allanderek.github.io/categories/python.xml]
 name = Coding Diet
 


### PR DESCRIPTION
It is spewing lots of non-Python-related content into the planet.

I plan to merge this PR tomorrow unless the feed cleans itself up.

/cc @joycelee11