### PR TITLE
Pr245 query params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /config/*.tmplc
 *.pyc
 *.pyo
+/.venv
+/_cache
+/_output

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,5 @@
+IF NOT EXIST _cache MKDIR _cache
+DEL /Q _cache\*
+IF NOT EXIST _output MKDIR _output
+
+py -2 code\planet.py --verbose config\config.ini

--- a/config/config.ini
+++ b/config/config.ini
@@ -14,2476 +14,3471 @@ activity_threshold = 180
 link = http://planetpython.org/
 template_files = config/index.html.tmpl config/rss20.xml.tmpl config/rss10.xml.tmpl config/opml.xml.tmpl config/foafroll.xml.tmpl config/summary.html.tmpl config/titles_only.html.tmpl
 cache_directory = /srv/cache
+last_checked = Sun Aug 27 11:56:47 2017
 
-[http://www.2general.com/blog/python.rss.html]
-name = 2General
+# [http://www.2general.com/blog/python.rss.html]
+# name = 2General
+# notes = 404 Client Error: Not Found for url: http://www.2general.com/blog/python.rss.html
+# last_checked = Sun Aug 27 11:56:47 2017
 
 [http://dev.2degreesnetwork.com/feeds/posts/default/-/python]
 name = 2degrees
+last_checked = Sun Aug 27 11:56:47 2017
 
 [http://devblog.4teamwork.ch/blog/categories/planet-python/atom.xml]
 name = 4teamwork
+last_checked = Sun Aug 27 11:56:47 2017
 
 [http://advocacy.python.org/podcasts/littlebit.rss]
 name = A Little Bit of Python
+last_checked = Sun Aug 27 11:56:47 2017
 
 [https://emptysqua.re/blog/category/python/index.xml]
 name = A. Jesse Jiryu Davis
+last_checked = Sun Aug 27 11:56:48 2017
 
 [http://ablog.readthedocs.org/blog/atom.xml]
 name = ABlog for Sphinx
+last_checked = Sun Aug 27 11:56:49 2017
 
-[http://engineering.aweber.com/category/python-2/feed/]
-name = AWeber Engineering
+# [http://engineering.aweber.com/category/python-2/feed/]
+# name = AWeber Engineering
+# notes = 403 Client Error: Forbidden for url: http://engineering.aweber.com/category/python-2/feed/
+# last_checked = Sun Aug 27 11:56:49 2017
 
 [http://www.artima.com/weblogs/feeds/bloggers/aahz.rss]
 name = Aahz
+last_checked = Sun Aug 27 11:56:49 2017
 
 [http://masnun.rocks/tags/python/index.xml]
 name = Abu Ashraf Masnun
+last_checked = Sun Aug 27 11:56:50 2017
 
 [http://techarttiki.blogspot.com/feeds/posts/default/-/python]
 name = Adam Pletcher
+last_checked = Sun Aug 27 11:56:50 2017
 
 [http://adrian.org.ar/tag/python/feed/atom/]
 name = Adrián Deccico
+last_checked = Sun Aug 27 11:56:50 2017
 
 [http://agendaless.com/blog/index.atom?category=python]
 name = Agendaless Consulting
+last_checked = Sun Aug 27 11:56:52 2017
 
 [http://alstatr.blogspot.com/feeds/posts/default/-/Python]
 name = Al-Ahmadgaid Asaad
+last_checked = Sun Aug 27 11:56:52 2017
 
 [http://marduk.ghost.io/tag/python/rss/]
 name = Albert Hopkins
+last_checked = Sun Aug 27 11:56:52 2017
 
 [http://alecmunro.blogspot.com/feeds/posts/default/-/python]
 name = Alec Munro
+last_checked = Sun Aug 27 11:56:52 2017
 
 [http://blog.aclark.net/blog/category/python/atom.xml]
 name = Alex Clark
+last_checked = Sun Aug 27 11:56:54 2017
 
-[http://alexgaynor.net/feeds/tags/python/]
-name = Alex Gaynor
+# [http://alexgaynor.net/feeds/tags/python/]
+# name = Alex Gaynor
+# notes = 404 Client Error: Not Found for url: https://alexgaynor.net/feeds/tags/python/
+# last_checked = Sun Aug 27 11:56:55 2017
 
 [http://alextechrants.blogspot.com/feeds/posts/default/-/python]
 name = Alex Grönholm
+last_checked = Sun Aug 27 11:56:55 2017
 
 [https://alexmorozov.github.io/feeds/tag-python.atom.xml]
 name = Alex Morozov
+last_checked = Sun Aug 27 11:56:55 2017
 
 [http://feeds.limi.net/on-python]
 name = Alexander Limi
+last_checked = Sun Aug 27 11:56:55 2017
 
-[http://blog.abourget.net/categories/python/feed.atom]
-name = Alexandre Bourget
+# [http://blog.abourget.net/categories/python/feed.atom]
+# name = Alexandre Bourget
+# notes = 404 Client Error: Not Found for url: https://blog.abourget.net/categories/python/feed.atom
+# last_checked = Sun Aug 27 11:56:56 2017
 
 [http://www.alexconrad.org/feeds/posts/default/-/python]
 name = Alexandre Conrad
+last_checked = Sun Aug 27 11:56:56 2017
 
 [http://peadrop.com/blog/category/python/feed/]
 name = Alexandre Vassalotti
+last_checked = Sun Aug 27 11:56:57 2017
 
 [http://feeds.feedburner.com/en_lexevorg]
 name = Alexey Evseev
+last_checked = Sun Aug 27 11:56:57 2017
 
-[http://un-pythonic.appspot.com/feeds/atom.xml]
-name = Ali Afshar
+# [http://un-pythonic.appspot.com/feeds/atom.xml]
+# name = Ali Afshar
+# notes = 404 Client Error: Not Found for url: http://un-pythonic.appspot.com/feeds/atom.xml
+# last_checked = Sun Aug 27 11:56:57 2017
 
 [http://akaptur.github.io/blog/categories/python/atom.xml]
 name = Allison Kaptur
+last_checked = Sun Aug 27 11:56:57 2017
 
-[http://blog.amir.rachum.com/tagged/python/rss]
-name = Amir Rachum
+# [http://blog.amir.rachum.com/tagged/python/rss]
+# name = Amir Rachum
+# notes = 502 Server Error: Bad Gateway for url: http://blog.amir.rachum.com/tagged/python/rss
+# last_checked = Sun Aug 27 11:56:57 2017
 
 [http://echorand.me/feeds/python.atom.xml]
 name = Amit Saha
+last_checked = Sun Aug 27 11:56:58 2017
 
 [http://blog.amjith.com/posts.atom?tag=python]
 name = Amjith Ramanujam
+last_checked = Sun Aug 27 11:56:59 2017
 
 [http://blog.amvtek.com/feeds/tags/python.atom.xml]
 name = AmvTek
+last_checked = Sun Aug 27 11:56:59 2017
 
 [https://anarc.at/tag/python-planet/index.rss]
 name = Anarcat
+last_checked = Sun Aug 27 11:57:00 2017
 
 [http://pyswarm.blogspot.com/feeds/posts/default]
 name = Anastasios Hatzis
+last_checked = Sun Aug 27 11:57:01 2017
 
 [http://techtonik.rainforce.org/feeds/posts/default/-/python]
 name = Anatoly Techtonik
+last_checked = Sun Aug 27 11:57:01 2017
 
 [http://aroberge.blogspot.com/atom.xml]
 name = Andre Roberge
+last_checked = Sun Aug 27 11:57:01 2017
 
 [https://www.andreagrandi.it/feeds/python.rss.xml]
 name = Andrea Grandi
+last_checked = Sun Aug 27 11:57:02 2017
 
 [http://dalkescientific.com/writings/diary/diary-rss.xml]
 name = Andrew Dalke
+last_checked = Sun Aug 27 11:57:03 2017
 
-[http://drozdyuk.blogspot.com/feeds/posts/default/-/python]
-name = Andriy Drozdyuk
+# [http://drozdyuk.blogspot.com/feeds/posts/default/-/python]
+# name = Andriy Drozdyuk
+# notes = 404 Client Error: Not Found for url: http://drozdyuk.blogspot.com/feeds/posts/default/-/python
+# last_checked = Sun Aug 27 11:57:03 2017
 
 [http://mindref.blogspot.com/feeds/posts/default/-/python]
 name = Andriy Kornatskyy
+last_checked = Sun Aug 27 11:57:03 2017
 
 [http://kendriu.com/feeds/python.atom.xml]
 name = Andrzej Skupień
+last_checked = Sun Aug 27 11:57:03 2017
 
 [http://mysql-python.blogspot.com/feeds/posts/default]
 name = Andy Dustman
+last_checked = Sun Aug 27 11:57:03 2017
 
 [http://andy.terrel.us/feeds/python-tag.rss.xml]
 name = Andy R. Terrel
+last_checked = Sun Aug 27 11:57:04 2017
 
-[http://halfcooked.com/blog/feed/]
-name = Andy Todd
+# [http://halfcooked.com/blog/feed/]
+# name = Andy Todd
+# notes = 404 Client Error: Not Found for url: http://halfcooked.com/blog/feed/
+# last_checked = Sun Aug 27 11:57:04 2017
 
 [https://nerandell.github.io/atom.xml]
 name = Ankit Chandawala
+last_checked = Sun Aug 27 11:57:04 2017
 
 [http://annaraven.blogspot.com/feeds/posts/default/-/python]
 name = Anna Martelli Ravenscroft
+last_checked = Sun Aug 27 11:57:04 2017
 
 [http://codingweasel.blogspot.com/feeds/posts/default/-/python]
 name = Anthony Baxter
+last_checked = Sun Aug 27 11:57:04 2017
 
 [http://kpoxit.blogspot.com/feeds/posts/default/-/python]
 name = Anton Belyaev
+last_checked = Sun Aug 27 11:57:05 2017
 
 [http://bobrochel.blogspot.com/feeds/posts/default/-/python]
 name = Anton Bobrov
+last_checked = Sun Aug 27 11:57:05 2017
 
 [https://anweshadas.in/tag/python/rss/]
 name = Anwesha Das
+last_checked = Sun Aug 27 11:57:05 2017
 
 [http://www.appneta.com/blog/tag/python-applications/feed/]
 name = AppNeta Blog
+last_checked = Sun Aug 27 11:57:07 2017
 
 [http://lucumr.pocoo.org/feed.atom]
 name = Armin Ronacher
+last_checked = Sun Aug 27 11:57:08 2017
 
 [http://arnavk.com/tags/python/index.xml]
 name = Arnav Khare
+last_checked = Sun Aug 27 11:57:08 2017
 
-[http://feeds.feedburner.com/PythonMyThoughtsLearnings]
-name = Ashish Dutt
+# [http://feeds.feedburner.com/PythonMyThoughtsLearnings]
+# name = Ashish Dutt
+# notes = 404 Client Error: Feed not found error: FeedBurner cannot locate this feed URI. for url: http://feeds.feedburner.com/PythonMyThoughtsLearnings
+# last_checked = Sun Aug 27 11:57:08 2017
 
 [http://pyfunc.blogspot.com/feeds/posts/default/-/python]
 name = Ashish Vidyarthi
+last_checked = Sun Aug 27 11:57:08 2017
 
 [http://xthought.org/feeds/latest/category/python/]
 name = Ashley Camba
+last_checked = Sun Aug 27 11:57:08 2017
 
 [http://astrocodeschool.com/feeds/all.rss.xml]
 name = Astro Code School
+last_checked = Sun Aug 27 11:57:09 2017
 
 [http://www.toolness.com/wp/?cat=11&feed=rss2]
 name = Atul Varma -- Toolness
+last_checked = Sun Aug 27 11:57:10 2017
 
 [http://www.codemakesmehappy.com/feeds/posts/default/-/Python]
 name = Audrey Roy Greenfeld
+last_checked = Sun Aug 27 11:57:10 2017
 
 [http://automatingosint.com/blog/category/python/feed/]
 name = Automating OSINT
+last_checked = Sun Aug 27 11:57:14 2017
 
 [http://baijum.blogspot.com/feeds/posts/default/-/python]
 name = Baiju Muthukadan
+last_checked = Sun Aug 27 11:57:14 2017
 
 [http://gbtami.github.io/feed.python.xml]
 name = Bajusz Tamás
+last_checked = Sun Aug 27 11:57:15 2017
 
-[http://importthis.tumblr.com/tagged/python/rss]
-name = Balthazar Rouberol
+# [http://importthis.tumblr.com/tagged/python/rss]
+# name = Balthazar Rouberol
+# notes = 404 Client Error: Not Found for url: https://importthis.tumblr.com/tagged/python#_=_
+# last_checked = Sun Aug 27 11:57:15 2017
 
 [http://bangalore.python.org.in/feed.xml]
 name = BangPypers
+last_checked = Sun Aug 27 11:57:16 2017
 
 [http://www.djangrrl.com/feeds/python/]
 name = Barbara Shaurette
+last_checked = Sun Aug 27 11:57:26 2017
 
-[http://www.wefearchange.org/feeds/posts/default]
-name = Barry Warsaw
+# [http://www.wefearchange.org/feeds/posts/default]
+# name = Barry Warsaw
+# notes = 404 Client Error: Not Found for url: https://www.wefearchange.org/feeds/posts/default
+# last_checked = Sun Aug 27 11:57:27 2017
 
 [http://www.bedjango.com/planet/feed/]
 name = BeDjango
+last_checked = Sun Aug 27 11:57:27 2017
 
-[http://be.groovie.org/tagged/python/rss]
-name = Ben Bangert
+# [http://be.groovie.org/tagged/python/rss]
+# name = Ben Bangert
+# notes = 404 Client Error: Not Found for url: https://be.groovie.org/tagged/python/rss
+# last_checked = Sun Aug 27 11:57:29 2017
 
 [http://codedstructure.blogspot.com/feeds/posts/default/-/python]
 name = Ben Bass
+last_checked = Sun Aug 27 11:57:29 2017
 
 [http://clusterbleep.net/blog/category/python/feed/]
 name = Ben Rousch
+last_checked = Sun Aug 27 11:57:31 2017
 
 [http://mrben.co.uk/feed/python/]
 name = Ben Tappin
+last_checked = Sun Aug 27 11:57:31 2017
 
 [http://pybites.blogspot.com/feeds/posts/default]
 name = Benjamin Peterson
+last_checked = Sun Aug 27 11:57:32 2017
 
-[http://just-another.net/feeds/tag/python/]
-name = Benjamin W. Smith
+# [http://just-another.net/feeds/tag/python/]
+# name = Benjamin W. Smith
+# notes = 403 Client Error: Forbidden for url: http://just-another.net/feeds/tag/python/
+# last_checked = Sun Aug 27 11:57:32 2017
 
 [http://www.benjiyork.com/blog/atom.xml]
 name = Benji York
+last_checked = Sun Aug 27 11:57:32 2017
 
 [http://zebert.blogspot.com/feeds/posts/default/-/python]
 name = Bertrand Mathieu
+last_checked = Sun Aug 27 11:57:33 2017
 
 [http://feeds.feedburner.com/thetaranights]
 name = Bhishan Bhandari
+last_checked = Sun Aug 27 11:57:33 2017
 
-[http://billmill.org/Rss/keyword/python]
-name = Bill Mill
+# [http://billmill.org/Rss/keyword/python]
+# name = Bill Mill
+# notes = 404 Client Error: Not Found for url: https://billmill.org/Rss/keyword/python
+# last_checked = Sun Aug 27 11:57:33 2017
 
 [http://news.open-bio.org/news/category/obf-projects/biopython/feed/atom/]
 name = BioPython News
+last_checked = Sun Aug 27 11:57:34 2017
 
 [http://bitofcheese.blogspot.com/feeds/posts/default]
 name = Bit of Cheese
+last_checked = Sun Aug 27 11:57:34 2017
 
-[http://tillenius.me/feeds/atom/tag/python/]
-name = Björn Tillenius
+# [http://tillenius.me/feeds/atom/tag/python/]
+# name = Björn Tillenius
+# notes = 404 Client Error: Not Found for url: http://tillenius.me/feeds/atom/tag/python/
+# last_checked = Sun Aug 27 11:57:35 2017
 
 [http://www.blendedtechnologies.com/category/python/rss/]
 name = Blended Technologies
+last_checked = Sun Aug 27 11:57:35 2017
 
 [https://tech.blue-yonder.com/tag/python/feed/]
 name = Blue Yonder Tech
+last_checked = Sun Aug 27 11:57:36 2017
 
 [http://bluebream.posterous.com/rss.xml]
 name = BlueBream
+last_checked = Sun Aug 27 11:57:36 2017
 
-[http://bluedynamics.com/pythonrelated/++feed++/@@rss.xml]
-name = BlueDynamics Alliance
+# [http://bluedynamics.com/pythonrelated/++feed++/@@rss.xml]
+# name = BlueDynamics Alliance
+# notes = 404 Client Error: Not Found for url: https://bluedynamics.com/pythonrelated/++feed++/@@rss.xml
+# last_checked = Sun Aug 27 11:57:36 2017
 
 [http://source.mihelac.org/feeds/categories/django/]
 name = Bojan Mihelac
+last_checked = Sun Aug 27 11:57:36 2017
 
 [http://blog.bradlucas.com/python.xml]
 name = Brad Lucas
+last_checked = Sun Aug 27 11:57:37 2017
 
 [http://rhodesmill.org/brandon/category/python/feed]
 name = Brandon Rhodes
+last_checked = Sun Aug 27 11:57:37 2017
 
 [https://breadcrumbscollector.tech/category/python/feed/]
 name = BreadcrumbsCollector
+last_checked = Sun Aug 27 11:57:38 2017
 
 [http://python4dads.wordpress.com/feed/]
 name = Brendan Scott
+last_checked = Sun Aug 27 11:57:38 2017
 
 [https://snarky.ca/rss/]
 name = Brett Cannon
+last_checked = Sun Aug 27 11:57:38 2017
 
 [http://blog.briancurtin.com/categories/python.xml]
 name = Brian Curtin
+last_checked = Sun Aug 27 11:57:39 2017
 
 [http://ferringb.wordpress.com/category/python/feed/atom/]
 name = Brian Harring
+last_checked = Sun Aug 27 11:57:39 2017
 
-[http://www.protocolostomy.com/category/technology/python/feed]
-name = Brian Jones
+# [http://www.protocolostomy.com/category/technology/python/feed]
+# name = Brian Jones
+# notes = 404 Client Error: Not Found for url: http://www.protocolostomy.com/category/technology/python/feed
+# last_checked = Sun Aug 27 11:57:39 2017
 
 [http://pythontesting.net/on/planet/feed]
 name = Brian Okken
+last_checked = Sun Aug 27 11:57:45 2017
 
 [http://nicoddemus.github.io/tag/python/atom.xml]
 name = Bruno Oliveira
+last_checked = Sun Aug 27 11:57:45 2017
 
 [http://brunorocha.org/tag/pythonplanet.atom]
 name = Bruno Rocha
+last_checked = Sun Aug 27 11:57:50 2017
 
-[http://scrollingtext.org/taxonomy/term/29/0/feed]
-name = Bryce Verdier
+# [http://scrollingtext.org/taxonomy/term/29/0/feed]
+# name = Bryce Verdier
+# notes = 404 Client Error: Not Found for url: http://scrollingtext.org/taxonomy/term/29/0/feed
+# last_checked = Sun Aug 27 11:57:50 2017
 
 [http://www.caktusgroup.com/feeds/tags/python/]
 name = Caktus Consulting Group
+last_checked = Sun Aug 27 11:57:54 2017
 
 [http://www.calvinx.com/category/code/python/feed/]
 name = Calvin Cheng
+last_checked = Sun Aug 27 11:57:57 2017
 
 [http://techblog.ironfroggy.com/feeds/posts/default/-/programming]
 name = Calvin Spealman
+last_checked = Sun Aug 27 11:57:57 2017
 
 [http://thelivingpearl.com/tag/python/feed/]
 name = "Captain DeadBones'' Chronicles"
+last_checked = Sun Aug 27 11:57:59 2017
 
 [http://carlchenet.com/category/planetpython/feed/]
 name = Carl Chenet
+last_checked = Sun Aug 27 11:58:00 2017
 
 [http://pyright.blogspot.com/feeds/posts/default?alt=rss]
 name = Carl Trachte
+last_checked = Sun Aug 27 11:58:00 2017
 
 [http://themindcaster.blogspot.com/feeds/posts/default/-/python]
 name = Carlos Eduardo de Paula
+last_checked = Sun Aug 27 11:58:00 2017
 
 [http://blog.delaguardia.com.mx/feed.atom]
 name = Carlos de la Guardia
+last_checked = Sun Aug 27 11:58:01 2017
 
 [http://eatthedots.blogspot.com/feeds/posts/default]
 name = Casey Duncan
+last_checked = Sun Aug 27 11:58:01 2017
 
 [http://python-catalin.blogspot.com/feeds/posts/default/-/python]
 name = Catalin George Festila
+last_checked = Sun Aug 27 11:58:02 2017
 
 [http://catherinedevlin.blogspot.com/feeds/posts/default/-/python]
 name = Catherine Devlin
+last_checked = Sun Aug 27 11:58:02 2017
 
-[http://www.super-cooper.com/archive/category/python/feed]
-name = Chad Cooper
+# [http://www.super-cooper.com/archive/category/python/feed]
+# name = Chad Cooper
+# notes = HTTPConnectionPool(host='www.super-cooper.com', port=80): Max retries exceeded with url: /archive/category/python/feed (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x03CA3270>: Failed to establish a new connection: [Errno 11001] getaddrinfo failed',))
+# last_checked = Sun Aug 27 11:58:02 2017
 
-[http://blag.whit537.org/feeds/posts/default/-/python]
-name = Chad Whitacre
+# [http://blag.whit537.org/feeds/posts/default/-/python]
+# name = Chad Whitacre
+# notes = 404 Client Error: Not Found for url: http://whit537.org/feeds/posts/default/-/python
+# last_checked = Sun Aug 27 11:58:03 2017
 
 [http://www.checkandshare.com/blog/?cat=2?&feed=rss2]
 name = Checking and Sharing
+last_checked = Sun Aug 27 11:58:07 2017
 
-[http://blog.chrisarndt.de/category/computer/coding/python/feed]
-name = Chris Arndt
+# [http://blog.chrisarndt.de/category/computer/coding/python/feed]
+# name = Chris Arndt
+# notes = 404 Client Error: Not Found for url: https://chrisarndt.de/category/computer/coding/python/feed
+# last_checked = Sun Aug 27 11:58:07 2017
 
 [http://metachris.org/category/python/feed/atom/]
 name = Chris Hager
+last_checked = Sun Aug 27 11:58:08 2017
 
 [http://blog.cdleary.com/category/programming/python/feed/]
 name = Chris Leary
+last_checked = Sun Aug 27 11:58:09 2017
 
 [http://weblog.lonelylion.com/category/python/feed]
 name = Chris McAvoy
+last_checked = Sun Aug 27 11:58:09 2017
 
-[http://plope.com/python.rss]
-name = Chris McDonough
+# [http://plope.com/python.rss]
+# name = Chris McDonough
+# notes = HTTPConnectionPool(host='plope.com', port=80): Max retries exceeded with url: /python.rss (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x03AA3250>: Failed to establish a new connection: [Errno 10060] A connection attempt failed because the connected party did not properly respond after a period of time or established connection failed because connected host has failed to respond',))
+# last_checked = Sun Aug 27 11:58:30 2017
 
 [http://chris-miles-writes-python.blogspot.com/feeds/posts/default?alt=rss]
 name = Chris Miles
+last_checked = Sun Aug 27 11:58:30 2017
 
 [http://www.unquietdesperation.com/category/python/feed]
 name = Chris Miller
+last_checked = Sun Aug 27 11:58:31 2017
 
 [http://pyinformatics.blogspot.com/feeds/posts/default]
 name = Chris Mitchell
+last_checked = Sun Aug 27 11:58:31 2017
 
 [http://pbpython.com/feeds/all.atom.xml]
 name = Chris Moffitt
+last_checked = Sun Aug 27 11:58:34 2017
 
-[http://percious.com/blog/feed]
-name = Chris Perkins
+# [http://percious.com/blog/feed]
+# name = Chris Perkins
+# notes = 404 Client Error: Not Found for url: http://percious.com/blog/feed
+# last_checked = Sun Aug 27 11:58:34 2017
 
 [http://ideas.offby1.net/feeds/tag-python.atom.xml]
 name = Chris Rose
+last_checked = Sun Aug 27 11:58:35 2017
 
 [http://feeds.feedburner.com/ChrisWarrickPython]
 name = Chris Warrick
+last_checked = Sun Aug 27 11:58:46 2017
 
-[http://www.chrisbarra.me/tags/python.xml]
-name = Christian Barra
+# [http://www.chrisbarra.me/tags/python.xml]
+# name = Christian Barra
+# notes = 404 Client Error: Not Found for url: http://chrisbarra.me/tags/python.xml
+# last_checked = Sun Aug 27 11:58:49 2017
 
 [http://lipyrary.blogspot.com/feeds/posts/default]
 name = Christian Heimes
+last_checked = Sun Aug 27 11:58:49 2017
 
-[http://www.technobabble.dk/feeds/tags/python/]
-name = Christian Joergensen
+# [http://www.technobabble.dk/feeds/tags/python/]
+# name = Christian Joergensen
+# notes = 404 Client Error: Not Found for url: https://www.technobabble.dk/feeds/tags/python/
+# last_checked = Sun Aug 27 11:58:49 2017
 
 [http://feeds.feedburner.com/mrtopf-python]
 name = Christian Scholz
+last_checked = Sun Aug 27 11:58:51 2017
 
 [https://cito.github.io/tags/python/index.xml]
 name = Christoph Zwerschke
+last_checked = Sun Aug 27 11:58:51 2017
 
-[http://the-space-station.com/tags/planet-python/feed.atom]
-name = Christopher Denter
+# [http://the-space-station.com/tags/planet-python/feed.atom]
+# name = Christopher Denter
+# notes = 404 Client Error: Not Found for url: http://the-space-station.com/tags/planet-python/feed.atom
+# last_checked = Sun Aug 27 11:58:51 2017
 
-[http://www.cmlenz.net/blog/python.xml]
-name = Christopher Lenz
+# [http://www.cmlenz.net/blog/python.xml]
+# name = Christopher Lenz
+# notes = 500 Server Error: Internal Server Error for url: https://www.cmlenz.net/python.xml
+# last_checked = Sun Aug 27 11:58:52 2017
 
-[http://www.percious.com/blog/?feed=rss2&cat=3]
-name = Christopher Perkins
+# [http://www.percious.com/blog/?feed=rss2&cat=3]
+# name = Christopher Perkins
+# notes = 404 Client Error: Not Found for url: http://www.percious.com/blog/?feed=rss2&cat=3
+# last_checked = Sun Aug 27 11:58:52 2017
 
 [http://www.evilchuck.com/feeds/posts/default/-/python]
 name = Chuck Thier
+last_checked = Sun Aug 27 11:58:55 2017
 
-[http://www.redmountainsw.com/wordpress/archives/category/python/feed/atom]
-name = Chui Tey
+# [http://www.redmountainsw.com/wordpress/archives/category/python/feed/atom]
+# name = Chui Tey
+# notes = Exceeded 30 redirects.
+# last_checked = Sun Aug 27 11:59:04 2017
 
 [http://csparpa.github.io/blog/feeds/python.atom.xml]
 name = Claudio Sparpaglione
+last_checked = Sun Aug 27 11:59:04 2017
 
-[http://cloudnumbers.com/category/python/feed/atom]
-name = Cloudnumbers
+# [http://cloudnumbers.com/category/python/feed/atom]
+# name = Cloudnumbers
+# notes = 404 Client Error: Not Found for url: http://cloudnumbers.com/category/python/feed/atom
+# last_checked = Sun Aug 27 11:59:04 2017
 
 [https://clusterhq.com/feed.python.xml]
 name = ClusterHQ
+last_checked = Sun Aug 27 11:59:05 2017
 
 [https://cobe.io/blog/categories/python.xml]
 name = Cobe.io
+last_checked = Sun Aug 27 11:59:05 2017
 
 [http://codesnipers.com/?q=taxonomy/term/16/0/feed]
 name = CodeSnipers
+last_checked = Sun Aug 27 11:59:05 2017
 
 [https://www.codementor.io/community/topic/python/feed]
 name = Codementor
+last_checked = Sun Aug 27 11:59:06 2017
 
 [http://allanderek.github.io/categories/python.xml]
 name = Coding Diet
+last_checked = Sun Aug 27 11:59:07 2017
 
 [http://oakwinter.com/code/category/python/feed/rss]
 name = Collin Winter
+last_checked = Sun Aug 27 11:59:07 2017
 
 [http://concretecloud.github.io/feeds/python.atom.xml]
 name = Concrete Clouds
+last_checked = Sun Aug 27 11:59:07 2017
 
-[http://continuum.io/blog/feed]
-name = Continuum Analytics Blog
+# [http://continuum.io/blog/feed]
+# name = Continuum Analytics Blog
+# notes = 404 Client Error: Not Found for url: https://www.continuum.io/blog/feed
+# last_checked = Sun Aug 27 11:59:09 2017
 
 [http://continuum.io/press/feed]
 name = Continuum Analytics News
+last_checked = Sun Aug 27 11:59:11 2017
 
-[http://continuum.io/blog/category/python/feed]
-name = Continuum Blog
+# [http://continuum.io/blog/category/python/feed]
+# name = Continuum Blog
+# notes = 404 Client Error: Not Found for url: https://www.continuum.io/blog/category/python/feed
+# last_checked = Sun Aug 27 11:59:12 2017
 
 [http://controlfd.com/feed.python.xml]
 name = "Control F'd"
+last_checked = Sun Aug 27 11:59:12 2017
 
 [http://www.coresoftwaregroup.com/blog/topics/python/@@rss.xml]
 name = Core Software
+last_checked = Sun Aug 27 11:59:13 2017
 
 [http://feeds.feedburner.com/goldblog/python]
 name = Corey Goldberg
+last_checked = Sun Aug 27 11:59:13 2017
 
 [http://depressedoptimism.com/?tag=python&format=rss]
 name = Corey Oordt
+last_checked = Sun Aug 27 11:59:15 2017
 
 [http://feeds.feedburner.com/cormoran-project]
 name = Cormoran Project
+last_checked = Sun Aug 27 11:59:15 2017
 
 [http://craigkerstiens.com/categories/python/atom.xml]
 name = Craig Kerstiens
+last_checked = Sun Aug 27 11:59:15 2017
 
-[http://labs.creativecommons.org/category/python/feed/]
-name = Creative Commons
+# [http://labs.creativecommons.org/category/python/feed/]
+# name = Creative Commons
+# notes = 404 Client Error: Not Found for url: https://labs.creativecommons.org/category/python/feed/
+# last_checked = Sun Aug 27 11:59:16 2017
 
 [http://feeds2.feedburner.com/portablecommandline]
 name = Cross-Platform Command Line Tools
+last_checked = Sun Aug 27 11:59:16 2017
 
 [http://feeds.feedburner.com/cubicweborg]
 name = CubicWeb
+last_checked = Sun Aug 27 11:59:18 2017
 
 [https://ntguardian.wordpress.com/category/python/feed/]
 name = Curtis Miller
+last_checked = Sun Aug 27 11:59:19 2017
 
 [http://dspillustrations.com/static/dspillustrations.rss.xml]
 name = DSPIllustrations.com
+last_checked = Sun Aug 27 11:59:19 2017
 
 [http://dailytechvideo.com/category/python/feed/]
 name = Daily Tech Video (Python)
+last_checked = Sun Aug 27 11:59:20 2017
 
 [http://blog.sandbox.lt/tag/rss/en/python]
 name = Dalius Dobravolskas
+last_checked = Sun Aug 27 11:59:20 2017
 
 [http://dfwpython.blogspot.com/feeds/posts/default]
 name = Dallas Fort Worth Pythoneers
+last_checked = Sun Aug 27 11:59:20 2017
 
 [http://www.damian.oquanta.info/categories/python.xml]
 name = Damián Avila
+last_checked = Sun Aug 27 11:59:20 2017
 
 [http://damyanon.net/tag/python/feed/]
 name = Damyan Bogoev
+last_checked = Sun Aug 27 11:59:21 2017
 
 [http://late.am/python.feed.xml]
 name = Dan Crosta
+last_checked = Sun Aug 27 11:59:23 2017
 
 [http://strombrg.blogspot.com/feeds/posts/default/-/Python]
 name = Dan Stromberg
+last_checked = Sun Aug 27 11:59:23 2017
 
 [http://dbader.org/blog/tags/python/rss]
 name = Daniel Bader
+last_checked = Sun Aug 27 11:59:24 2017
 
-[http://www.endlesslycurious.com/tag/python/feed/]
-name = Daniel Brown
+# [http://www.endlesslycurious.com/tag/python/feed/]
+# name = Daniel Brown
+# notes = 404 Client Error: Not Found for url: http://www.endlesslycurious.com/tag/python/feed/
+# last_checked = Sun Aug 27 11:59:25 2017
 
 [http://danielnouri.org/notes/category/python/feed/index.xml]
 name = Daniel Nouri
+last_checked = Sun Aug 27 11:59:25 2017
 
 [https://www.pydanny.com/feeds/python.atom.xml]
 name = Daniel Roy Greenfeld
+last_checked = Sun Aug 27 11:59:25 2017
 
-[http://www.gefira.pl/blog/tag/planet-python/feed/]
-name = Dariusz Suchojad
+# [http://www.gefira.pl/blog/tag/planet-python/feed/]
+# name = Dariusz Suchojad
+# notes = 404 Client Error: Not Found for url: http://www.gefira.pl/blog/tag/planet-python/feed/
+# last_checked = Sun Aug 27 11:59:26 2017
 
-[http://datacommunitydc.org/blog/tag/python/feed/]
-name = Data Community DC
+# [http://datacommunitydc.org/blog/tag/python/feed/]
+# name = Data Community DC
+# notes = 404 Client Error: Not Found for url: http://www.datacommunitydc.org/tag/python/feed
+# last_checked = Sun Aug 27 11:59:27 2017
 
 [http://www.dataschool.io/tag/python/rss/]
 name = Data School
+last_checked = Sun Aug 27 11:59:27 2017
 
 [https://www.datacamp.com/community/blog/python-feed.rss]
 name = DataCamp
+last_checked = Sun Aug 27 11:59:28 2017
 
 [https://www.dataquest.io/blog/tag/python/index.xml]
 name = Dataquest
+last_checked = Sun Aug 27 11:59:29 2017
 
 [http://dabeaz.blogspot.com/feeds/posts/default]
 name = Dave Beazley
+last_checked = Sun Aug 27 11:59:29 2017
 
-[http://davebehnke.com/feeds/python.atom.xml]
-name = Dave Behnke
+# [http://davebehnke.com/feeds/python.atom.xml]
+# name = Dave Behnke
+# notes = 404 Client Error: Not Found for url: http://davebehnke.com/feeds/python.atom.xml
+# last_checked = Sun Aug 27 11:59:30 2017
 
-[http://hwit.org/feeds/python.atom.xml]
-name = Dave Haynes
+# [http://hwit.org/feeds/python.atom.xml]
+# name = Dave Haynes
+# notes = 404 Client Error: Not Found for url: http://hwit.org/feeds/python.atom.xml
+# last_checked = Sun Aug 27 11:59:30 2017
 
 [http://www.artima.com/weblogs/feeds/bloggers/goodger.rss]
 name = David Goodger
+last_checked = Sun Aug 27 11:59:30 2017
 
 [http://www.davidgrant.ca/taxonomy/term/14/0/feed]
 name = David Grant
+last_checked = Sun Aug 27 11:59:31 2017
 
-[http://www.djcinnovations.com/archives/category/python/feed/atom]
-name = David J C Beach
+# [http://www.djcinnovations.com/archives/category/python/feed/atom]
+# name = David J C Beach
+# notes = HTTPConnectionPool(host='www.djcinnovations.com', port=80): Max retries exceeded with url: /archives/category/python/feed/atom (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x04069D70>: Failed to establish a new connection: [Errno 10060] A connection attempt failed because the connected party did not properly respond after a period of time or established connection failed because connected host has failed to respond',))
+# last_checked = Sun Aug 27 11:59:52 2017
 
-[http://thppython.blogspot.com/feeds/posts/default]
-name = David Janes
+# [http://thppython.blogspot.com/feeds/posts/default]
+# name = David Janes
+# notes = 404 Client Error: Not Found for url: http://thppython.blogspot.com/feeds/posts/default
+# last_checked = Sun Aug 27 11:59:52 2017
 
 [http://www.drmaciver.com/category/python/feed/]
 name = David MacIver
+last_checked = Sun Aug 27 11:59:52 2017
 
 [http://dmalcolm.livejournal.com/data/atom?tag=python]
 name = David Malcolm
+last_checked = Sun Aug 27 11:59:55 2017
 
 [http://www.redesigndavid.com/atom?&tags=python]
 name = David Marte
+last_checked = Sun Aug 27 11:59:59 2017
 
-[http://www.traceback.org/category/python/feed]
-name = David Stanek
+# [http://www.traceback.org/category/python/feed]
+# name = David Stanek
+# notes = 403 Client Error: Forbidden for url: http://www.traceback.org/category/python/feed/
+# last_checked = Sun Aug 27 11:59:59 2017
 
 [http://www.szotten.com/david/feeds/python.atom.xml]
 name = David Szotten
+last_checked = Sun Aug 27 12:00:00 2017
 
-[http://codeinthehole.com/writing/tagged/python/feed/]
-name = David Winterbottom
+# [http://codeinthehole.com/writing/tagged/python/feed/]
+# name = David Winterbottom
+# notes = 404 Client Error: Not Found for url: http://codeinthehole.com/writing/tagged/python/feed/
+# last_checked = Sun Aug 27 12:00:00 2017
 
 [http://davidemoro.blogspot.com/feeds/posts/default/-/planetpython]
 name = Davide Moro
+last_checked = Sun Aug 27 12:00:00 2017
 
 [http://feeds2.feedburner.com/Daftpython]
 name = Davy Mitchell
+last_checked = Sun Aug 27 12:00:00 2017
 
 [http://davywybiral.blogspot.com/feeds/posts/default]
 name = Davy Wybiral
+last_checked = Sun Aug 27 12:00:01 2017
 
 [http://www.luckydonkey.com/category/python/rss]
 name = Dazza
+last_checked = Sun Aug 27 12:00:01 2017
 
 [http://degizmo.com/feed/]
 name = DeGizmo
+last_checked = Sun Aug 27 12:00:02 2017
 
 [http://makkalot-opensource.blogspot.com/feeds/posts/default/-/python]
 name = Denis Kurov
+last_checked = Sun Aug 27 12:00:02 2017
 
-[http://derrickpetzold.com/index.php/tag/python/feed/atom/]
-name = Derrick Petzold
+# [http://derrickpetzold.com/index.php/tag/python/feed/atom/]
+# name = Derrick Petzold
+# notes = 404 Client Error: Not Found for url: https://derrickpetzold.com/index.php/tag/python/feed/atom/
+# last_checked = Sun Aug 27 12:00:03 2017
 
 [http://livingcode.org/tag/python.atom]
 name = Dethe Elza
+last_checked = Sun Aug 27 12:00:04 2017
 
-[http://chaos.caltech.edu/cgi-bin/diane-planetpython-feed.py]
-name = Diane Trout
+# [http://chaos.caltech.edu/cgi-bin/diane-planetpython-feed.py]
+# name = Diane Trout
+# notes = 404 Client Error: Not Found for url: http://chaos.caltech.edu/cgi-bin/diane-planetpython-feed.py
+# last_checked = Sun Aug 27 12:00:04 2017
 
 [http://www.diego-garcia.info/python.atom.xml]
 name = Diego Garcia
+last_checked = Sun Aug 27 12:00:05 2017
 
 [http://www.djangoproject.com/rss/weblog/]
 name = Django Weblog
+last_checked = Sun Aug 27 12:00:05 2017
 
 [http://djangoweekly.com/blog/feed/]
 name = Django Weekly
+last_checked = Sun Aug 27 12:00:06 2017
 
 [http://django.zone/blog/posts/rss/]
 name = Django Zone
+last_checked = Sun Aug 27 12:00:07 2017
 
-[http://www.djangocon.org/blog/feeds/rss/latest/]
-name = Djangocon
+# [http://www.djangocon.org/blog/feeds/rss/latest/]
+# name = Djangocon
+# notes = HTTPConnectionPool(host='www.djangocon.org', port=80): Max retries exceeded with url: /blog/feeds/rss/latest/ (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x03CA38D0>: Failed to establish a new connection: [Errno 11002] getaddrinfo failed',))
+# last_checked = Sun Aug 27 12:00:07 2017
 
-[http://www.djangofoo.com/feed]
-name = Djangofeed
+# [http://www.djangofoo.com/feed]
+# name = Djangofeed
+# notes = HTTPConnectionPool(host='www.djangofoo.com', port=80): Max retries exceeded with url: /feed (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x03CA3650>: Failed to establish a new connection: [Errno 11001] getaddrinfo failed',))
+# last_checked = Sun Aug 27 12:00:07 2017
 
 [http://djangostars.com/blog/category/python/rss/]
 name = Djangostars
+last_checked = Sun Aug 27 12:00:07 2017
 
 [http://doingmathwithpython.github.io/feeds/all.atom.xml]
 name = Doing Math with Python
+last_checked = Sun Aug 27 12:00:07 2017
 
 [http://feeds.doughellmann.com/doughellmann/python]
 name = Doug Hellmann
+last_checked = Sun Aug 27 12:00:07 2017
 
 [http://douglatornell.ca/blog/category/python/feed/index.xml]
 name = Doug Latornell
+last_checked = Sun Aug 27 12:00:08 2017
 
 [http://www.dougalmatthews.com/feeds/python.atom.xml]
 name = Dougal Matthews
+last_checked = Sun Aug 27 12:00:08 2017
 
-[http://dougma.com/category/python/feed/]
-name = Douglas Napoleone
+# [http://dougma.com/category/python/feed/]
+# name = Douglas Napoleone
+# notes = 503 Server Error: Service Temporarily Unavailable for url: http://dougma.com/category/python/feed/
+# last_checked = Sun Aug 27 12:00:09 2017
 
-[http://dreamhost.com/dreamscape/tag/python/feed/]
-name = DreamHost
+# [http://dreamhost.com/dreamscape/tag/python/feed/]
+# name = DreamHost
+# notes = 404 Client Error: Not Found for url: https://www.dreamhost.com/dreamscape/tag/python/feed/
+# last_checked = Sun Aug 27 12:00:09 2017
 
 [http://oubiwann.blogspot.com/feeds/posts/default/-/python]
 name = Duncan McGreggor
+last_checked = Sun Aug 27 12:00:10 2017
 
-[http://buchuki.com/index.php/feed/]
-name = Dusty Phillips
+# [http://buchuki.com/index.php/feed/]
+# name = Dusty Phillips
+# notes = 404 Client Error: Not Found for url: http://buchuki.com/index.php/feed/
+# last_checked = Sun Aug 27 12:00:10 2017
 
 [http://easygui.wordpress.com/feed/atom/]
 name = EasyGUI
+last_checked = Sun Aug 27 12:00:10 2017
 
 [http://edcrewe.blogspot.com/feeds/posts/default/-/python]
 name = Ed Crewe
+last_checked = Sun Aug 27 12:00:10 2017
 
 [http://feeds.feedburner.com/RoadWarriorCollaborationPython]
 name = Ed Taekema
+last_checked = Sun Aug 27 12:00:11 2017
 
 [http://edreamleo.blogspot.com/feeds/posts/default/-/python]
 name = Edward K. Ream
+last_checked = Sun Aug 27 12:00:11 2017
 
 [http://pythonthusiast.pythonblogs.com/230_pythonthusiast/feeds/rss20]
 name = Eko S. Wibowo
+last_checked = Sun Aug 27 12:00:12 2017
 
 [http://eli.thegreenplace.net/feeds/python.atom.xml]
 name = Eli Bendersky
+last_checked = Sun Aug 27 12:00:13 2017
 
 [http://touilleman.xyz/blog/category/python/feed/index.xml]
 name = Emmanuel Leblond
+last_checked = Sun Aug 27 12:00:13 2017
 
 [http://eniramltd.github.io/devblog/rss/categories/python.xml]
 name = Eniram Ltd.
+last_checked = Sun Aug 27 12:00:14 2017
 
-[http://blog.enthought.com/?feed=rss2]
-name = Enthought
+# [http://blog.enthought.com/?feed=rss2]
+# name = Enthought
+# notes = 403 Client Error: Forbidden for url: http://blog.enthought.com/?feed=rss2
+# last_checked = Sun Aug 27 12:00:14 2017
 
 [https://examachine.net/blog/category/python/feed/]
 name = Eray Özkural (examachine)
+last_checked = Sun Aug 27 12:00:14 2017
 
-[http://www.eflorenzano.com/blog/feeds/posts/python/]
-name = Eric Florenzano
+# [http://www.eflorenzano.com/blog/feeds/posts/python/]
+# name = Eric Florenzano
+# notes = 404 Client Error: Not Found for url: http://eflorenzano.com/blog/feeds/posts/python/
+# last_checked = Sun Aug 27 12:00:15 2017
 
 [http://ericholscher.com/blog/archive/tag/python/atom.xml]
 name = Eric Holscher
+last_checked = Sun Aug 27 12:00:16 2017
 
 [http://pythonfilter.com/rss.xml]
 name = "Eric Wu's Pythonfilter"
+last_checked = Sun Aug 27 12:00:16 2017
 
 [http://www.marsja.se/category/python/feed/]
 name = Erik Marsja
+last_checked = Sun Aug 27 12:00:16 2017
 
 [http://etienned.github.io/categories/python.xml]
 name = Etienne Desautels
+last_checked = Sun Aug 27 12:00:16 2017
 
 [http://blog.europython.eu/rss]
 name = EuroPython
+last_checked = Sun Aug 27 12:00:17 2017
 
 [http://www.europython-society.org/rss]
 name = EuroPython Society
+last_checked = Sun Aug 27 12:00:17 2017
 
-[http://www.evanfosmark.com/category/programming/python/feed]
-name = Evan Fosmark
+# [http://www.evanfosmark.com/category/programming/python/feed]
+# name = Evan Fosmark
+# notes = HTTPConnectionPool(host='www.evanfosmark.com', port=80): Max retries exceeded with url: /category/programming/python/feed (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x040705F0>: Failed to establish a new connection: [Errno 11002] getaddrinfo failed',))
+# last_checked = Sun Aug 27 12:00:18 2017
 
 [http://blog.python-eve.org/feeds/rss.xml]
 name = Eve REST Framework
+last_checked = Sun Aug 27 12:00:18 2017
 
-[http://eventh.tumblr.com/tagged/Python/rss]
-name = Even Wiik Thomassen
+# [http://eventh.tumblr.com/tagged/Python/rss]
+# name = Even Wiik Thomassen
+# notes = 404 Client Error: Not Found for url: https://eventh.tumblr.com/tagged/Python#_=_
+# last_checked = Sun Aug 27 12:00:19 2017
 
 [http://evennia.blogspot.com/feeds/posts/default]
 name = Evennia
+last_checked = Sun Aug 27 12:00:20 2017
 
-[http://interactivepython.org/courselib/feed/everyday.rss]
-name = Everyday Python
+# [http://interactivepython.org/courselib/feed/everyday.rss]
+# name = Everyday Python
+# notes = 404 Client Error: NOT FOUND for url: http://interactivepython.org/courselib/feed/everyday.rss
+# last_checked = Sun Aug 27 12:00:20 2017
 
 [http://www.snowboardingcoder.com/django/?feed=rss2]
 name = Experienced Django
+last_checked = Sun Aug 27 12:00:22 2017
 
 [http://pydev.blogspot.com/atom.xml]
 name = Fabio Zadrozny
+last_checked = Sun Aug 27 12:00:23 2017
 
 [http://www.majid.info/mylos/weblog/categories/python/rss.xml]
 name = Fazal Majid
+last_checked = Sun Aug 27 12:00:25 2017
 
 [http://en.ig.ma/notebook/feeds/atom/tag/python.xml]
 name = Filip Wasilewski
+last_checked = Sun Aug 27 12:00:25 2017
 
 [http://blog.filipesaraiva.info/?feed=rss2&tag=planet-python]
 name = Filipe Saraiva
+last_checked = Sun Aug 27 12:00:26 2017
 
 [http://pyinsci.blogspot.com/feeds/posts/default]
 name = Flavio Coelho
+last_checked = Sun Aug 27 12:00:27 2017
 
 [http://blog.flaper87.com/feeds/python.atom.xml]
 name = Flavio Percoco
+last_checked = Sun Aug 27 12:00:27 2017
 
 [http://blog.devork.be/feeds/posts/default/-/python]
 name = Floris Bruynooghe
+last_checked = Sun Aug 27 12:00:27 2017
 
-[http://www.franciscosouza.net/feeds/posts/default/-/python]
-name = Francisco Souza
+# [http://www.franciscosouza.net/feeds/posts/default/-/python]
+# name = Francisco Souza
+# notes = 530 Server Error:  for url: http://www.franciscosouza.net/feeds/posts/default/-/python
+# last_checked = Sun Aug 27 12:00:27 2017
 
 [http://fwierzbicki.blogspot.com/atom.xml]
 name = Frank Wierzbicki
+last_checked = Sun Aug 27 12:00:28 2017
 
 [http://raspberry-python.blogspot.com/feeds/posts/default/-/english/python]
 name = François Dion
+last_checked = Sun Aug 27 12:00:29 2017
 
 [http://feeding.cloud.geek.nz/tags/python/index.rss]
 name = François Marier
+last_checked = Sun Aug 27 12:00:30 2017
 
 [http://www.fridh.nl/tag/python.atom.xml]
 name = Frederik Rietdijk
+last_checked = Sun Aug 27 12:00:30 2017
 
 [http://blaag.haard.se/python.xml]
 name = "Fredrik Håård's Blaag"
+last_checked = Sun Aug 27 12:00:31 2017
 
 [http://online.effbot.org/rss.xml]
 name = Fredrik Lundh
+last_checked = Sun Aug 27 12:00:32 2017
 
 [http://feeds.feedburner.com/FromPythonImportPodcast]
 name = From Python Import Podcast
+last_checked = Sun Aug 27 12:00:32 2017
 
 [https://www.fullstackpython.com/feeds/all.atom.xml]
 name = Full Stack Python
+last_checked = Sun Aug 27 12:00:33 2017
 
 [http://gael-varoquaux.info/feeds/programming.atom.xml]
 name = Ga&#235;l Varoquaux
+last_checked = Sun Aug 27 12:00:34 2017
 
 [http://blog.tshirtman.fr/tags/python/feed.atom]
 name = Gabriel Pettier
+last_checked = Sun Aug 27 12:00:52 2017
 
 [http://www.galvanize.com/blog/tag/python/feed/]
 name = Galvanize
+last_checked = Sun Aug 27 12:00:55 2017
 
-[http://blog.extracheese.org/feeds/posts/default/-/python]
-name = Gary Bernhardt
+# [http://blog.extracheese.org/feeds/posts/default/-/python]
+# name = Gary Bernhardt
+# notes = HTTPConnectionPool(host='blog.extracheese.org', port=80): Max retries exceeded with url: /feeds/posts/default/-/python (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x0407BB10>: Failed to establish a new connection: [Errno 10060] A connection attempt failed because the connected party did not properly respond after a period of time or established connection failed because connected host has failed to respond',))
+# last_checked = Sun Aug 27 12:01:16 2017
 
 [http://feeds.feedburner.com/garyrobinson/python]
 name = Gary Robinson
+last_checked = Sun Aug 27 12:01:17 2017
 
 [http://thegarywilson.com/blog/feed/python/]
 name = Gary Wilson
+last_checked = Sun Aug 27 12:01:18 2017
 
-[http://philipson.co.il/blog/categories/python/atom.xml]
-name = Gavrie Philipson
+# [http://philipson.co.il/blog/categories/python/atom.xml]
+# name = Gavrie Philipson
+# notes = 404 Client Error: Not Found for url: http://philipson.co.il/blog/categories/python/atom.xml
+# last_checked = Sun Aug 27 12:01:18 2017
 
 [http://geekscrap.com/feed/?tag=python]
 name = Geek Scrap
+last_checked = Sun Aug 27 12:01:18 2017
 
-[http://geert.vanderkelen.org/tag/python/feed/atom/]
-name = Geert Vanderkelen
+# [http://geert.vanderkelen.org/tag/python/feed/atom/]
+# name = Geert Vanderkelen
+# notes = 404 Client Error: Not Found for url: https://geert.vanderkelen.org/tag/python/feed/atom/
+# last_checked = Sun Aug 27 12:01:19 2017
 
 [http://blog.picante.co.nz/latest/feed/]
 name = Gene Campbell
+last_checked = Sun Aug 27 12:01:19 2017
 
-[http://pythonic.pocoo.org/feed.atom]
-name = Georg Brandl
+# [http://pythonic.pocoo.org/feed.atom]
+# name = Georg Brandl
+# notes = 400 Client Error: Bad Request for url: http://pythonic.pocoo.org/feed.atom
+# last_checked = Sun Aug 27 12:01:19 2017
 
 [http://compiletoi.net/feeds/python.atom.xml]
 name = Georges Dubus
+last_checked = Sun Aug 27 12:01:20 2017
 
 [http://ghaandeeonit.tumblr.com/rss]
 name = Ghaandee on IT
+last_checked = Sun Aug 27 12:01:20 2017
 
 [http://www.grodola.blogspot.com/feeds/posts/default/-/python]
 name = Giampaolo Rodola
+last_checked = Sun Aug 27 12:01:20 2017
 
-[http://g.raphaelli.com/tags/python/feed.atom]
-name = Gilad Raphaelli
+# [http://g.raphaelli.com/tags/python/feed.atom]
+# name = Gilad Raphaelli
+# notes = 404 Client Error: Not Found for url: http://g.raphaelli.com/tags/python/feed.atom
+# last_checked = Sun Aug 27 12:01:21 2017
 
 [http://giuliofidente.com/feeds/tag/python.atom.xml]
 name = Giulio Fidente
+last_checked = Sun Aug 27 12:01:21 2017
 
 [http://hackermojo.com/mt-static/tagged/python.rdf]
 name = Glenn Franxman
+last_checked = Sun Aug 27 12:01:22 2017
 
 [http://glyph.twistedmatrix.com/feeds/posts/default]
 name = Glyph Lefkowitz
+last_checked = Sun Aug 27 12:01:23 2017
 
 [http://feeds.feedburner.com/GoDeh]
 name = Go Deh
+last_checked = Sun Aug 27 12:01:23 2017
 
 [https://godjango.com/rss/main/]
 name = GoDjango
+last_checked = Sun Aug 27 12:01:24 2017
 
 [http://blog.gocept.com/tag/python/feed/atom/]
 name = Gocept Weblog
+last_checked = Sun Aug 27 12:01:25 2017
 
 [http://blog.godson.in/feeds/posts/default/-/Python]
 name = Godson Gera
+last_checked = Sun Aug 27 12:01:25 2017
 
 [http://devalien.com/rss.php?module=blog&cat=python]
 name = Gonçalo Margalho
+last_checked = Sun Aug 27 12:01:29 2017
 
 [http://www.curiousvenn.com/?feed=rss2&cat=4]
 name = Graeme Cross
+last_checked = Sun Aug 27 12:01:32 2017
 
 [http://blog.dscpl.com.au/feeds/posts/default]
 name = Graham Dumpleton
+last_checked = Sun Aug 27 12:01:32 2017
 
 [http://gramps-project.org/category/programming/feed/atom/]
 name = Gramps
+last_checked = Sun Aug 27 12:01:33 2017
 
 [http://defrobnication.blogspot.com/feeds/posts/default/-/python]
 name = Grant Baillie
+last_checked = Sun Aug 27 12:01:34 2017
 
 [http://www.wisdomandwonder.com/tag/python/feed]
 name = Grant Rettke
+last_checked = Sun Aug 27 12:01:35 2017
 
 [http://gc-taylor.com/?format=rss&category=Python]
 name = Greg Taylor
+last_checked = Sun Aug 27 12:01:36 2017
 
 [http://greg-turnquist.blogspot.com/feeds/posts/default/-/spring%20python]
 name = Greg Turnquist
+last_checked = Sun Aug 27 12:01:36 2017
 
 [http://pyre.third-bit.com/blog/archives/category/python/feed?format=atom]
 name = Greg Wilson
+last_checked = Sun Aug 27 12:01:37 2017
 
 [http://www.answermysearches.com/index.php/category/python/feed/]
 name = Gregory Pinero
+last_checked = Sun Aug 27 12:01:38 2017
 
 [http://agiletesting.blogspot.com/feeds/posts/default/-/python]
 name = Grig Gheorghiu
+last_checked = Sun Aug 27 12:01:38 2017
 
 [http://blog.fizyk.net.pl/tags/python.xml]
 name = Grzegorz Śliwiński
+last_checked = Sun Aug 27 12:01:38 2017
 
-[http://blog.kollerie.com/feeds/Python.atom.xml]
-name = Guido Kollerie
+# [http://blog.kollerie.com/feeds/Python.atom.xml]
+# name = Guido Kollerie
+# notes = HTTPConnectionPool(host='blog.kollerie.com', port=80): Max retries exceeded with url: /feeds/Python.atom.xml (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x03CA5050>: Failed to establish a new connection: [Errno 10060] A connection attempt failed because the connected party did not properly respond after a period of time or established connection failed because connected host has failed to respond',))
+# last_checked = Sun Aug 27 12:01:59 2017
 
 [http://neopythonic.blogspot.com/feeds/posts/default]
 name = Guido van Rossum
+last_checked = Sun Aug 27 12:02:00 2017
 
-[guilhermetoti.com.br/feeds/all.atom.xml]
-name = Guilherme Toti
+# [guilhermetoti.com.br/feeds/all.atom.xml]
+# name = Guilherme Toti
+# notes = Invalid URL 'guilhermetoti.com.br/feeds/all.atom.xml': No schema supplied. Perhaps you meant http://guilhermetoti.com.br/feeds/all.atom.xml?
+# last_checked = Sun Aug 27 12:02:00 2017
 
 [http://gustavonarea.net/blog/tags/python/feed/]
 name = Gustavo Narea
+last_checked = Sun Aug 27 12:02:01 2017
 
 [http://blog.labix.org/tag/python/feed]
 name = Gustavo Niemeyer
+last_checked = Sun Aug 27 12:02:02 2017
 
 [http://feeds.feedburner.com/gumuznl]
 name = Guyon Moree
+last_checked = Sun Aug 27 12:02:03 2017
 
 [http://pycloud.blogspot.com/feeds/posts/default/-/python]
 name = Gökhan Sever
+last_checked = Sun Aug 27 12:02:03 2017
 
-[http://blog.hannosch.eu/feeds/posts/default/-/python?alt=rss]
-name = Hanno Schlichting
+# [http://blog.hannosch.eu/feeds/posts/default/-/python?alt=rss]
+# name = Hanno Schlichting
+# notes = 404 Client Error: Not Found for url: http://blog.hannosch.eu/feeds/posts/default/-/python?alt=rss
+# last_checked = Sun Aug 27 12:02:03 2017
 
 [http://blog.vmfarms.com/feeds/posts/default/-/python]
 name = Hany Fahim
+last_checked = Sun Aug 27 12:02:03 2017
 
 [http://blog.patx.me/rss]
 name = Harrison Erd
+last_checked = Sun Aug 27 12:02:04 2017
 
 [http://nomadblue.com/feeds/python/]
 name = Hector Garcia
+last_checked = Sun Aug 27 12:02:05 2017
 
 [http://www.heikkitoivonen.net/blog/category/python/feed/atom/]
 name = Heikki Toivonen
+last_checked = Sun Aug 27 12:02:06 2017
 
 [http://python-in-the-lab.blogspot.de//feeds/posts/default/-/Python]
 name = Hernan Grecco
+last_checked = Sun Aug 27 12:02:06 2017
 
 [http://www.hilarymason.com/tag/python/feed/]
 name = Hilary Mason
+last_checked = Sun Aug 27 12:02:07 2017
 
 [http://tetamap.wordpress.com/feed/atom/]
 name = Holger Krekel
+last_checked = Sun Aug 27 12:02:08 2017
 
 [http://www.holger-peters.de/feeds/python.atom.xml]
 name = Holger Peters
+last_checked = Sun Aug 27 12:02:09 2017
 
-[http://www.huyng.com/atom.xml]
-name = Huy Nguyen
+# [http://www.huyng.com/atom.xml]
+# name = Huy Nguyen
+# notes = HTTPConnectionPool(host='www.huyng.com', port=80): Max retries exceeded with url: /atom.xml (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x03CAC7B0>: Failed to establish a new connection: [Errno 11002] getaddrinfo failed',))
+# last_checked = Sun Aug 27 12:02:09 2017
 
 [https://hynek.me/feed-python.xml]
 name = Hynek Schlawack
+last_checked = Sun Aug 27 12:02:10 2017
 
 [http://www.iodigitalsec.com/category/python/feed/]
 name = IO Digital Sec
+last_checked = Sun Aug 27 12:02:11 2017
 
-[http://blog.ianbicking.org/category/python/feed/atom/]
-name = Ian Bicking
+# [http://blog.ianbicking.org/category/python/feed/atom/]
+# name = Ian Bicking
+# notes = 404 Client Error: Not Found for url: http://www.ianbicking.org/category/python/feed/atom/
+# last_checked = Sun Aug 27 12:02:11 2017
 
 [http://ianozsvald.com/category/python/feed/atom/]
 name = Ian Ozsvald
+last_checked = Sun Aug 27 12:02:12 2017
 
 [http://ilian.i-n-i.org/feed/?tag=python]
 name = Ilian Iliev
+last_checked = Sun Aug 27 12:02:13 2017
 
 [http://chidjango.dev.imagescape.com/blog/feeds/rss/]
 name = Imaginary Landscape
+last_checked = Sun Aug 27 12:02:14 2017
 
 [http://importpython.com/blog/feed/]
 name = Import Python
+last_checked = Sun Aug 27 12:02:14 2017
 
 [http://intellimath.bitbucket.org/blog/categories/python.xml]
 name = Intellimath blog
+last_checked = Sun Aug 27 12:02:16 2017
 
-[http://inventwithpython.com/blog/feed/atom/]
-name = Invent with Python
+# [http://inventwithpython.com/blog/feed/atom/]
+# name = Invent with Python
+# notes = 404 Client Error: Not Found for url: http://inventwithpython.com/blog/feed/atom/
+# last_checked = Sun Aug 27 12:02:16 2017
 
-[http://www.talaikis.com/python/feed/]
-name = Investing using Python
+# [http://www.talaikis.com/python/feed/]
+# name = Investing using Python
+# notes = 404 Client Error: Not Found for url: https://talaikis.com/python/feed/
+# last_checked = Sun Aug 27 12:02:17 2017
 
 [https://blog.ionelmc.ro/feeds/python.atom.xml]
 name = Ionel Cristian Mărieș
+last_checked = Sun Aug 27 12:02:18 2017
 
-[http://python123.org/feed/]
-name = Iraj Jelodari
+# [http://python123.org/feed/]
+# name = Iraj Jelodari
+# notes = 404 Client Error: Not Found for url: http://python123.org/feed/
+# last_checked = Sun Aug 27 12:02:19 2017
 
 [http://ironpython-urls.blogspot.com/feeds/posts/default]
 name = IronPython-URLs
+last_checked = Sun Aug 27 12:02:19 2017
 
 [http://ishan.chattopadhyaya.com/blog/?feed=rss2&cat=17]
 name = Ishan Chattopadhyaya
+last_checked = Sun Aug 27 12:02:20 2017
 
-[http://blog.isotoma.com/atom.xml]
-name = Isotoma
+# [http://blog.isotoma.com/atom.xml]
+# name = Isotoma
+# notes = 404 Client Error: Not Found for url: https://www.isotoma.com/blog/atom.xml
+# last_checked = Sun Aug 27 12:02:21 2017
 
 [http://fruch.github.io/feed.python.xml]
 name = Israel Fruchter
+last_checked = Sun Aug 27 12:02:21 2017
 
 [http://codewithoutrules.com/python-atom.xml]
 name = Itamar Turner Trauring
+last_checked = Sun Aug 27 12:02:22 2017
 
-[http://radian.org/notebook/feed/atom]
-name = Ivan Krstic
+# [http://radian.org/notebook/feed/atom]
+# name = Ivan Krstic
+# notes = HTTPConnectionPool(host='radian.org', port=80): Max retries exceeded with url: /notebook/feed/atom (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x0407BE90>: Failed to establish a new connection: [Errno 10061] No connection could be made because the target machine actively refused it',))
+# last_checked = Sun Aug 27 12:02:23 2017
 
 [http://jackdied.blogspot.com/feeds/posts/default]
 name = Jack Diederich
+last_checked = Sun Aug 27 12:02:24 2017
 
 [http://feeds.feedburner.com/StreamHackerPython]
 name = Jacob Perkins
+last_checked = Sun Aug 27 12:02:26 2017
 
 [http://wrongsideofmemphis.wordpress.com/feed/atom/?tag=english+python]
 name = Jaime Buelta
+last_checked = Sun Aug 27 12:02:27 2017
 
 [http://www.datadependence.com/tag/python/feed/]
 name = Jamal Moir
+last_checked = Sun Aug 27 12:02:30 2017
 
-[http://shortcircuit.net.au/~prologic/blog/feeds/tags/python.atom.xml]
-name = James Mills
+# [http://shortcircuit.net.au/~prologic/blog/feeds/tags/python.atom.xml]
+# name = James Mills
+# notes = HTTPConnectionPool(host='shortcircuit.net.au', port=80): Max retries exceeded with url: /~prologic/blog/feeds/tags/python.atom.xml (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x04070330>: Failed to establish a new connection: [Errno 10060] A connection attempt failed because the connected party did not properly respond after a period of time or established connection failed because connected host has failed to respond',))
+# last_checked = Sun Aug 27 12:02:52 2017
 
 [http://listbot.org/python.xml]
 name = James Polera
+last_checked = Sun Aug 27 12:02:52 2017
 
-[http://jtauber.com/atom/full/]
-name = James Tauber
+# [http://jtauber.com/atom/full/]
+# name = James Tauber
+# notes = 404 Client Error: Not Found for url: http://jtauber.com/atom/full/
+# last_checked = Sun Aug 27 12:02:52 2017
 
-[http://opkode.net/media/blog/search_rss?portal_type=WeblogEntry&Subject=python]
-name = Jan-Carel Brand
+# [http://opkode.net/media/blog/search_rss?portal_type=WeblogEntry&Subject=python]
+# name = Jan-Carel Brand
+# notes = 500 Server Error: Internal Server Error for url: http://opkode.net/media/blog/search_rss?portal_type=WeblogEntry&Subject=python
+# last_checked = Sun Aug 27 12:02:52 2017
 
 [https://janusworx.com/tag/python/rss]
 name = Janusworx
+last_checked = Sun Aug 27 12:02:55 2017
 
-[http://jaredforsyth.com/feeds/category/python/]
-name = Jared Forsyth
+# [http://jaredforsyth.com/feeds/category/python/]
+# name = Jared Forsyth
+# notes = 404 Client Error: Not Found for url: https://jaredforsyth.com/feeds/category/python/
+# last_checked = Sun Aug 27 12:02:55 2017
 
 [http://blog.jarrodmillman.com/feeds/posts/default/-/python]
 name = Jarrod Millman
+last_checked = Sun Aug 27 12:02:56 2017
 
-[http://pipes.yahoo.com/pipes/pipe.run?_id=97756b01119b35e1215f3bcbdda71b92&_render=rss]
-name = Jason Baker
+# [http://pipes.yahoo.com/pipes/pipe.run?_id=97756b01119b35e1215f3bcbdda71b92&_render=rss]
+# name = Jason Baker
+# notes = HTTPConnectionPool(host='pipes.yahoo.com', port=80): Max retries exceeded with url: /pipes/pipe.run?_id=97756b01119b35e1215f3bcbdda71b92&_render=rss (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x04070910>: Failed to establish a new connection: [Errno 11001] getaddrinfo failed',))
+# last_checked = Sun Aug 27 12:02:56 2017
 
 [http://www.jasonamyers.com/feed]
 name = Jason Meyers
+last_checked = Sun Aug 27 12:02:56 2017
 
 [http://www.bigjason.com/tags/python.atom]
 name = Jason Webb
+last_checked = Sun Aug 27 12:02:57 2017
 
 [http://blog.jaysinh.com/tags/python/feed.xml]
 name = Jaysinh Shukla
+last_checked = Sun Aug 27 12:02:57 2017
 
 [http://ganwell.github.io/feeds/python.atom.xml]
 name = Jean-Louis Fuchs
+last_checked = Sun Aug 27 12:02:58 2017
 
 [http://as.ynchrono.us/feeds/posts/default/-/python]
 name = Jean-Paul Calderone
+last_checked = Sun Aug 27 12:02:58 2017
 
 [http://jeetworks.org/python/feed]
 name = Jeet Sukumaran
+last_checked = Sun Aug 27 12:03:00 2017
 
-[http://jeethurao.com/blog/?feed=rss2&tag=python]
-name = Jeethu Rao
+# [http://jeethurao.com/blog/?feed=rss2&tag=python]
+# name = Jeethu Rao
+# notes = 502 Server Error: Bad Gateway for url: http://jeethurao.com/blog/?feed=rss2&tag=python
+# last_checked = Sun Aug 27 12:03:00 2017
 
 [http://jbisbee.blogspot.com/feeds/posts/default/-/python]
 name = Jeff Bisbee
+last_checked = Sun Aug 27 12:03:00 2017
 
 [http://jeffbradberry.com/feeds/python.atom.xml]
 name = Jeff Bradberry
+last_checked = Sun Aug 27 12:03:01 2017
 
 [http://inre.dundeemt.com/category/python/feed/]
 name = Jeff Hinrichs
+last_checked = Sun Aug 27 12:03:02 2017
 
 [http://www.jeffknupp.com/blog/categories/python/atom.xml]
 name = Jeff Knupp
+last_checked = Sun Aug 27 12:03:03 2017
 
 [http://feeds.feedburner.com/WebInfrastructureSystemsDeploymentsAndTechnologiesPython]
 name = Jeff McNeil
+last_checked = Sun Aug 27 12:03:04 2017
 
 [http://thoughtamps.blogspot.com/feeds/posts/default]
 name = Jeff Rush
+last_checked = Sun Aug 27 12:03:04 2017
 
 [http://griddlenoise.blogspot.com/feeds/posts/default/-/python]
 name = Jeff Shell
+last_checked = Sun Aug 27 12:03:04 2017
 
 [http://jeffwinkler.net/category/python/feed]
 name = Jeff Winkler
+last_checked = Sun Aug 27 12:03:05 2017
 
 [http://greenash.net.au/thoughts/topics/python/rss/]
 name = Jeremy Epstein
+last_checked = Sun Aug 27 12:03:06 2017
 
 [http://jeremyhylton.blogspot.com/atom.xml]
 name = Jeremy Hylton
+last_checked = Sun Aug 27 12:03:06 2017
 
-[http://housewifehacker.com/rss/category/Python.rss]
-name = Jessie Anderson
+# [http://housewifehacker.com/rss/category/Python.rss]
+# name = Jessie Anderson
+# notes = 404 Client Error: Not Found for url: http://housewifehacker.com/rss/category/Python.rss
+# last_checked = Sun Aug 27 12:03:06 2017
 
-[http://zyasoft.com/pythoneering/atom.xml]
-name = Jim Baker
+# [http://zyasoft.com/pythoneering/atom.xml]
+# name = Jim Baker
+# notes = HTTPConnectionPool(host='zyasoft.com', port=80): Max retries exceeded with url: /pythoneering/atom.xml (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x040709F0>: Failed to establish a new connection: [Errno 11001] getaddrinfo failed',))
+# last_checked = Sun Aug 27 12:03:06 2017
 
 [http://www.blogger.com/feeds/6330681631629046724/posts/default]
 name = Jim Fulton
+last_checked = Sun Aug 27 12:03:07 2017
 
 [http://feetup.org/blog/dev/python?flav=rss]
 name = Jim Hughes
+last_checked = Sun Aug 27 12:03:08 2017
 
 [http://pyrseas.wordpress.com/tag/python/feed/atom/]
 name = Joe Abbate
+last_checked = Sun Aug 27 12:03:08 2017
 
 [http://feeds.feedburner.com/JoePitz-TechnologyBlogPython]
 name = Joe Pitz
+last_checked = Sun Aug 27 12:03:08 2017
 
 [http://blogs.gnome.org/johan/category/python/feed/atom]
 name = Johan Dahlin
+last_checked = Sun Aug 27 12:03:10 2017
 
-[http://sontek.net/blog/rss/tag/python.rss]
-name = John Anderson
+# [http://sontek.net/blog/rss/tag/python.rss]
+# name = John Anderson
+# notes = HTTPConnectionPool(host='sontek.net', port=80): Max retries exceeded with url: /blog/rss/tag/python.rss (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x03AA3B90>: Failed to establish a new connection: [Errno 10060] A connection attempt failed because the connected party did not properly respond after a period of time or established connection failed because connected host has failed to respond',))
+# last_checked = Sun Aug 27 12:03:32 2017
 
 [http://clouddbs.blogspot.com/feeds/posts/default/-/python]
 name = John Burns
+last_checked = Sun Aug 27 12:03:32 2017
 
 [http://www.johndcook.com/blog/category/python/feed/]
 name = John Cook
+last_checked = Sun Aug 27 12:03:35 2017
 
-[http://www.johngag.com/feed/python/]
-name = John Gagliardi
+# [http://www.johngag.com/feed/python/]
+# name = John Gagliardi
+# notes = 404 Client Error: Not Found for url: http://www.johngag.com/feed/python/
+# last_checked = Sun Aug 27 12:03:35 2017
 
 [http://eigenhombre.com/feed.python.xml]
 name = John Jacobsen
+last_checked = Sun Aug 27 12:03:36 2017
 
 [http://jhcore.com/tag/python/feed]
 name = John Paulett
+last_checked = Sun Aug 27 12:03:37 2017
 
 [http://www.indelible.org/feeds/ink/python.xml]
 name = Jon Parise
+last_checked = Sun Aug 27 12:03:37 2017
 
 [http://hashbeat.blogspot.com/feeds/posts/default/-/Python]
 name = Jonathan Dobson
+last_checked = Sun Aug 27 12:03:38 2017
 
 [http://spyced.blogspot.com/feeds/posts/default/-/python]
 name = Jonathan Ellis
+last_checked = Sun Aug 27 12:03:38 2017
 
 [http://feeds.feedburner.com/JonathansPythonBlog]
 name = Jonathan Harrington
+last_checked = Sun Aug 27 12:03:39 2017
 
 [http://www.tartley.com/?feed=rss2&cat=10]
 name = Jonathan Hartley
+last_checked = Sun Aug 27 12:03:40 2017
 
 [http://www.cleverdevil.org/?rss=1&section=computing]
 name = Jonathan LaCour
+last_checked = Sun Aug 27 12:03:45 2017
 
 [http://jonathanstreet.com/blog/tag/python/atom/]
 name = Jonathan Street
+last_checked = Sun Aug 27 12:03:46 2017
 
-[http://www.jordan-dimov.com/python/atom.xml]
-name = Jordan Dimov
+# [http://www.jordan-dimov.com/python/atom.xml]
+# name = Jordan Dimov
+# notes = 404 Client Error: Not Found for url: https://www.jordan-dimov.com/python?format=rss
+# last_checked = Sun Aug 27 12:03:47 2017
 
 [http://www.metaklass.org/rss/]
 name = Jorge Niedbalski
+last_checked = Sun Aug 27 12:03:48 2017
 
 [http://puentesarr.in/category/python/feed/]
 name = Jorge Puente Sarrín
+last_checked = Sun Aug 27 12:03:48 2017
 
 [http://blog.jorgenschaefer.de/feeds/posts/default/-/Python]
 name = Jorgen Schäfer
+last_checked = Sun Aug 27 12:03:48 2017
 
 [http://joao.in/blog/category/python/rss/]
 name = João Laia
+last_checked = Sun Aug 27 12:03:49 2017
 
 [http://pythonmonopoly.wordpress.com/feed/]
 name = Juan Manuel Contreras
+last_checked = Sun Aug 27 12:03:49 2017
 
-[http://blog.superadditive.com/category/python/feed]
-name = Juan Rivas
+# [http://blog.superadditive.com/category/python/feed]
+# name = Juan Rivas
+# notes = 404 Client Error: Not Found for url: http://blog.superadditive.com/category/python/feed
+# last_checked = Sun Aug 27 12:03:50 2017
 
 [http://www.juanrodriguezmonti.com.ar/tags/python/index.xml]
 name = Juan Rodríguez Monti
+last_checked = Sun Aug 27 12:03:50 2017
 
 [http://nixtu.blogspot.com/feeds/posts/default/-/python]
 name = Juho Vepsäläinen
+last_checked = Sun Aug 27 12:03:51 2017
 
 [http://julien.danjou.info/blog/tags/Python.xml]
 name = Julien Danjou
+last_checked = Sun Aug 27 12:03:51 2017
 
 [http://dev-tricks.net/category/code/python/feed]
 name = Julien Palard
+last_checked = Sun Aug 27 12:03:51 2017
 
 [http://beauty-of-imagination.blogspot.fr/feeds/posts/default/-/python]
 name = Julien Tayon
+last_checked = Sun Aug 27 12:03:52 2017
 
-[http://www.iki.fi/juri/blog/index.rss]
-name = Juri Pakaste
+# [http://www.iki.fi/juri/blog/index.rss]
+# name = Juri Pakaste
+# notes = 403 Client Error: Forbidden for url: http://juripakaste.fi/blog/index.rss
+# last_checked = Sun Aug 27 12:03:52 2017
 
 [http://pythonisito.blogspot.com/feeds/posts/default]
 name = Just a little Python
+last_checked = Sun Aug 27 12:03:53 2017
 
 [http://feeds.hackercodex.com/feeds/python]
 name = Justin Mayer
+last_checked = Sun Aug 27 12:03:53 2017
 
-[http://diefenba.ch/rss/blog?tags=python]
-name = Kai Diefenbach
+# [http://diefenba.ch/rss/blog?tags=python]
+# name = Kai Diefenbach
+# notes = 502 Server Error: Bad Gateway for url: http://dfnb.ch/rss/blog?tags=python
+# last_checked = Sun Aug 27 12:03:54 2017
 
 [http://lautaportti.wordpress.com/feed/atom/]
 name = Kai Lautaportti
+last_checked = Sun Aug 27 12:03:54 2017
 
 [http://newafricanlifestyle.com/category/python/feed/]
 name = Kamon Ayeva
+last_checked = Sun Aug 27 12:03:55 2017
 
 [http://littlegreenriver.com/weblog/tag/python-2/feed/atom/]
 name = Karen Rustad
+last_checked = Sun Aug 27 12:03:55 2017
 
 [http://kate-editor.org/tag/python/feed/atom/]
 name = Kate Editor
+last_checked = Sun Aug 27 12:03:56 2017
 
-[http://therealkatie.net/blog/python/feed/]
-name = Katie Cunningham
+# [http://therealkatie.net/blog/python/feed/]
+# name = Katie Cunningham
+# notes = 404 Client Error: Not Found for url: http://therealkatie.net/blog/python/feed/
+# last_checked = Sun Aug 27 12:03:56 2017
 
 [http://nuitka.net/categories/Python.xml]
 name = Kay Hayen
+last_checked = Sun Aug 27 12:03:56 2017
 
 [http://fiber-space.de/wordpress/category/python/feed]
 name = Kay Schluehr
+last_checked = Sun Aug 27 12:03:59 2017
 
 [http://kbyanc.blogspot.com/feeds/posts/default/-/python]
 name = Kelly Yancey
+last_checked = Sun Aug 27 12:03:59 2017
 
-[http://www.kennethreitz.org/?category=Development&format=rss]
-name = Kenneth Reitz
+# [http://www.kennethreitz.org/?category=Development&format=rss]
+# name = Kenneth Reitz
+# notes = 400 Client Error: Bad Request for url: https://www.kennethreitz.org/?category=Development&format=rss
+# last_checked = Sun Aug 27 12:04:00 2017
 
 [http://powertwenty.com/kpd/blog/?feed=rss2&cat=3]
 name = Kevin Dahlhausen
+last_checked = Sun Aug 27 12:04:02 2017
 
 [http://www.blueskyonmars.com/category/python/feed/]
 name = Kevin Dangoor
+last_checked = Sun Aug 27 12:04:02 2017
 
-[http://nz.pycon.org/feeds/blog/]
-name = Kiwi PyCon
+# [http://nz.pycon.org/feeds/blog/]
+# name = Kiwi PyCon
+# notes = 404 Client Error: NOT FOUND for url: https://python.nz/feeds/blog/
+# last_checked = Sun Aug 27 12:04:03 2017
 
 [http://konryd.blogspot.com/feeds/posts/default]
 name = Konrad Delong
+last_checked = Sun Aug 27 12:04:03 2017
 
 [https://koodaamo.wordpress.com/category/python/feed]
 name = Koodaamo
+last_checked = Sun Aug 27 12:04:04 2017
 
 [http://kracekumar.com/tagged/python/rss]
 name = Kracekumar Ramaraju
+last_checked = Sun Aug 27 12:04:04 2017
 
 [http://cosmicpercolator.com/category/python/feed/atom/]
 name = Kristján Valur Jónsson
+last_checked = Sun Aug 27 12:04:05 2017
 
 [http://blog.kritigodey.com/tag/python/rss]
 name = Kriti Godey
+last_checked = Sun Aug 27 12:04:06 2017
 
-[http://krys.ca/category/python/feed/atom/1.0/]
-name = Krys Wilken
+# [http://krys.ca/category/python/feed/atom/1.0/]
+# name = Krys Wilken
+# notes = 429 Client Error: Too Many Requests for url: http://www.krys.ca/category/python/feed/atom/1.0/
+# last_checked = Sun Aug 27 12:04:07 2017
 
 [https://krzysztofzuraw.com/feeds/python.rss.xml]
 name = Krzysztof Żuraw
+last_checked = Sun Aug 27 12:04:07 2017
 
 [http://gofedora.com/archives/category/python/feed/]
 name = Kulbir Saini
+last_checked = Sun Aug 27 12:04:08 2017
 
 [http://farmdev.com/feeds/thoughts/on/3/python/]
 name = Kumar McMillan
+last_checked = Sun Aug 27 12:04:08 2017
 
-[http://www.kunxi.org/tag/python/feed]
-name = Kun Xi
+# [http://www.kunxi.org/tag/python/feed]
+# name = Kun Xi
+# notes = 404 Client Error: Not Found for url: https://www.kunxi.org/tag/python/feed
+# last_checked = Sun Aug 27 12:04:09 2017
 
-[http://kurtgrandis.com/blog/category/python/feed]
-name = Kurt Grandis
+# [http://kurtgrandis.com/blog/category/python/feed]
+# name = Kurt Grandis
+# notes = HTTPConnectionPool(host='kurtgrandis.com', port=80): Max retries exceeded with url: /blog/category/python/feed (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x03AA33D0>: Failed to establish a new connection: [Errno 10060] A connection attempt failed because the connected party did not properly respond after a period of time or established connection failed because connected host has failed to respond',))
+# last_checked = Sun Aug 27 12:04:30 2017
 
 [http://kushaldas.in/categories/python.xml]
 name = Kushal Das
+last_checked = Sun Aug 27 12:04:31 2017
 
 [http://charlesnagy.info/category/it/python/feed/]
 name = Károly Nagy
+last_checked = Sun Aug 27 12:04:32 2017
 
 [http://feeds.feedburner.com/shuttlethread-python]
 name = Laurence Rowe
+last_checked = Sun Aug 27 12:04:33 2017
 
 [http://www.laurentluce.com/posts/tag/python/feed/]
 name = Laurent Luce
+last_checked = Sun Aug 27 12:04:35 2017
 
 [http://laurentszyster.be/blog/feed/]
 name = Laurent Szyster
+last_checked = Sun Aug 27 12:04:36 2017
 
-[http://feeds2.feedburner.com/ASongForTheLovers]
-name = Lawrence Oluyede
+# [http://feeds2.feedburner.com/ASongForTheLovers]
+# name = Lawrence Oluyede
+# notes = 404 Client Error: Feed not found error: FeedBurner cannot locate this feed URI. for url: http://feeds2.feedburner.com/ASongForTheLovers
+# last_checked = Sun Aug 27 12:04:36 2017
 
-[http://blog.irukado.org/category/python/feed/]
-name = Lee Braiden
+# [http://blog.irukado.org/category/python/feed/]
+# name = Lee Braiden
+# notes = HTTPConnectionPool(host='blog.irukado.org', port=80): Max retries exceeded with url: /category/python/feed/ (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x0407BDF0>: Failed to establish a new connection: [Errno 10060] A connection attempt failed because the connected party did not properly respond after a period of time or established connection failed because connected host has failed to respond',))
+# last_checked = Sun Aug 27 12:04:57 2017
 
 [http://hypatia.ca/tag/python/feed/]
 name = Leigh Honeywell
+last_checked = Sun Aug 27 12:04:57 2017
 
 [http://regebro.wordpress.com/category/python/feed/atom/]
 name = Lennart Regebro
+last_checked = Sun Aug 27 12:04:58 2017
 
 [http://leovt.wordpress.com/category/python/feed/atom/]
 name = Leonhard Vogt
+last_checked = Sun Aug 27 12:04:59 2017
 
-[http://lesscode.org/feed/]
-name = Lesscode.org
+# [http://lesscode.org/feed/]
+# name = Lesscode.org
+# notes = 404 Client Error: Not Found for url: http://lesscode.org/feed/
+# last_checked = Sun Aug 27 12:05:00 2017
 
 [http://levipy.com/python_feed.xml]
 name = Levi Velázquez
+last_checked = Sun Aug 27 12:05:00 2017
 
-[http://www.lfcproject.com/feeds/django]
-name = Lightning Fast CMS
+# [http://www.lfcproject.com/feeds/django]
+# name = Lightning Fast CMS
+# notes = 404 Client Error: NOT FOUND for url: http://www.lfcproject.com/feeds/django
+# last_checked = Sun Aug 27 12:05:00 2017
 
 [http://www.getlfs.com/rss/blog]
 name = Lightning Fast Shop
+last_checked = Sun Aug 27 12:05:00 2017
 
 [http://blog.lintel.in/tag/python/feed/]
 name = Lintel Technologies
+last_checked = Sun Aug 27 12:05:02 2017
 
-[http://lion.posterous.com/rss.xml?tag=planetpython]
-name = Lion Kimbro
+# [http://lion.posterous.com/rss.xml?tag=planetpython]
+# name = Lion Kimbro
+# notes = 503 Server Error: Service Unavailable for url: http://lion.posterous.com/rss.xml?tag=planetpython
+# last_checked = Sun Aug 27 12:05:07 2017
 
 [http://lionel.textmalaysia.com/category/programming/python/feed]
 name = Lionel Tan
+last_checked = Sun Aug 27 12:05:07 2017
 
 [http://feeds.feedburner.com/logilaborg_en]
 name = Logilab
+last_checked = Sun Aug 27 12:05:07 2017
 
 [http://lowkster.blogspot.com/feeds/posts/default]
 name = Low Kian Seong
+last_checked = Sun Aug 27 12:05:08 2017
 
 [http://codingandlinux.blogspot.com/feeds/posts/default/-/python]
 name = Luca Botti
+last_checked = Sun Aug 27 12:05:08 2017
 
 [http://blog.gmludo.eu/feeds/posts/default/-/python]
 name = Ludovic Gasc
+last_checked = Sun Aug 27 12:05:08 2017
 
 [http://blog.ludovf.net/feed/python/atom/]
 name = Ludovico Fischer
+last_checked = Sun Aug 27 12:05:08 2017
 
 [http://bsg.lericson.se/rssfiltered.rss]
 name = Ludvig Ericson
+last_checked = Sun Aug 27 12:05:09 2017
 
 [http://lewk.org/blog/tags/Python?flav=atom]
 name = Luke Macken
+last_checked = Sun Aug 27 12:05:10 2017
 
 [http://lukeplant.me.uk/blog/categories/python/atom/index.xml]
 name = Luke Plant
+last_checked = Sun Aug 27 12:05:10 2017
 
 [http://machinalis.com/blog/tag/python/feeds/rss/]
 name = Machinalis
+last_checked = Sun Aug 27 12:05:13 2017
 
 [http://lostinjit.blogspot.com/feeds/posts/default]
 name = Maciej Fijalkowsk
+last_checked = Sun Aug 27 12:05:13 2017
 
 [http://www.mahdiyusuf.com/tagged/python/rss]
 name = Mahdi Yusuf
+last_checked = Sun Aug 27 12:05:14 2017
 
 [http://sedimental.org/tagged/python/atom.xml]
 name = Mahmoud Hashemi
+last_checked = Sun Aug 27 12:05:14 2017
 
 [https://maltheborch.com/rss?tags=python]
 name = Malthe Borch
+last_checked = Sun Aug 27 12:05:15 2017
 
-[http://www.themacaque.com/?tag=python&feed=rss2]
-name = Manuel de la Pena Saenz
+# [http://www.themacaque.com/?tag=python&feed=rss2]
+# name = Manuel de la Pena Saenz
+# notes = HTTPConnectionPool(host='www.themacaque.com', port=80): Max retries exceeded with url: /?tag=python&feed=rss2 (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x03CAC790>: Failed to establish a new connection: [Errno 10060] A connection attempt failed because the connected party did not properly respond after a period of time or established connection failed because connected host has failed to respond',))
+# last_checked = Sun Aug 27 12:05:36 2017
 
 [http://vaig.be/feeds/posts/default/-/Python]
 name = Marc Garcia
+last_checked = Sun Aug 27 12:05:37 2017
 
 [http://mkerins.ghost.io/tag/python/rss/]
 name = Marc Kerins
+last_checked = Sun Aug 27 12:05:37 2017
 
 [http://www.malemburg.com/rss]
 name = Marc-André Lemburg
+last_checked = Sun Aug 27 12:05:37 2017
 
-[http://www.python-blog.com/feed/atom/]
-name = Marcin Kuźmiński
+# [http://www.python-blog.com/feed/atom/]
+# name = Marcin Kuźmiński
+# notes = 404 Client Error: Not Found for url: http://www.python-blog.com/feed/atom/
+# last_checked = Sun Aug 27 12:05:37 2017
 
 [http://www.grulic.org.ar/~mdione/glob/tags/python/index.atom]
 name = Marcos Dione
+last_checked = Sun Aug 27 12:05:39 2017
 
-[http://marcuswhybrow.net/tag/python/feed/atom/]
-name = Marcus Whybrow
+# [http://marcuswhybrow.net/tag/python/feed/atom/]
+# name = Marcus Whybrow
+# notes = 404 Client Error: Not Found for url: http://marcuswhybrow.com/tag/python/feed/atom/
+# last_checked = Sun Aug 27 12:05:40 2017
 
 [http://pysnippet.com/feeds/posts/default/-/Python]
 name = Mario Boikov
+last_checked = Sun Aug 27 12:05:40 2017
 
 [http://mg.pov.lt/blog/index.xml]
 name = Marius Gedminas
+last_checked = Sun Aug 27 12:05:41 2017
 
 [http://stochasticgeometry.com/category/python/feed/atom/]
 name = Mark Dennehy
+last_checked = Sun Aug 27 12:05:41 2017
 
 [http://shed-skin.blogspot.com/feeds/posts/default]
 name = Mark Dufour
+last_checked = Sun Aug 27 12:05:41 2017
 
 [http://blogs.gnome.org/markmc/category/python/feed/]
 name = Mark McLoughlin
+last_checked = Sun Aug 27 12:05:43 2017
 
 [http://pywinauto.blogspot.com/atom.xml]
 name = Mark McMahon
+last_checked = Sun Aug 27 12:05:44 2017
 
 [http://www.learningpython.com/feed/]
 name = Mark Mruss
+last_checked = Sun Aug 27 12:05:45 2017
 
-[http://markpasc.org/weblog/index.rdf]
-name = Mark Paschal
+# [http://markpasc.org/weblog/index.rdf]
+# name = Mark Paschal
+# notes = 404 Client Error: Not Found for url: https://markpasc.org/weblog/index.rdf
+# last_checked = Sun Aug 27 12:05:46 2017
 
-[http://compoundthinking.com/blog/index.php/category/python/feed]
-name = Mark Ramm
+# [http://compoundthinking.com/blog/index.php/category/python/feed]
+# name = Mark Ramm
+# notes = 408 Client Error: Request Timeout for url: http://compoundthinking.com/blog/index.php/category/python/feed
+# last_checked = Sun Aug 27 12:05:47 2017
 
 [http://markos.gaivo.net/articles/feeds/python.atom.xml]
 name = Marko Samastur
+last_checked = Sun Aug 27 12:05:48 2017
 
 [http://blog.startifact.com/categories/planetpython.xml]
 name = Martijn Faassen
+last_checked = Sun Aug 27 12:05:48 2017
 
 [http://feeds.feedburner.com/zopatista/python]
 name = Martijn Pieters
+last_checked = Sun Aug 27 12:05:48 2017
 
-[http://furius.ca/blog/tag/Python/rss]
-name = Martin Blais
+# [http://furius.ca/blog/tag/Python/rss]
+# name = Martin Blais
+# notes = 404 Client Error: Not Found for url: http://furius.ca/blog/tag/Python/rss
+# last_checked = Sun Aug 27 12:05:49 2017
 
 [http://martinfitzpatrick.name/feeds/python.tag.atom.xml]
 name = Martin Fitzpatrick
+last_checked = Sun Aug 27 12:05:50 2017
 
-[http://stompstompstomp.com/weblog/technical/rss]
-name = Mathieu Fenniak
+# [http://stompstompstomp.com/weblog/technical/rss]
+# name = Mathieu Fenniak
+# notes = HTTPConnectionPool(host='stompstompstomp.com', port=80): Max retries exceeded with url: /weblog/technical/rss (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x03CA3610>: Failed to establish a new connection: [Errno 11001] getaddrinfo failed',))
+# last_checked = Sun Aug 27 12:05:50 2017
 
 [http://txzone.net/category/python/feed]
 name = Mathieu Virbel
+last_checked = Sun Aug 27 12:05:50 2017
 
 [http://mysqlmusings.blogspot.se/feeds/posts/default/-/python]
 name = Mats Kindahl
+last_checked = Sun Aug 27 12:05:51 2017
 
 [http://mattgoodall.blogspot.com/atom.xml]
 name = Matt Goodall
+last_checked = Sun Aug 27 12:05:51 2017
 
 [http://hairysun.com/python.xml]
 name = Matt Harrison
+last_checked = Sun Aug 27 12:05:52 2017
 
-[http://themattreid.com/wordpress/category/python/feed/]
-name = Matt Reid
+# [http://themattreid.com/wordpress/category/python/feed/]
+# name = Matt Reid
+# notes = HTTPConnectionPool(host='themattreid.com', port=80): Max retries exceeded with url: /wordpress/category/python/feed/ (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x04070330>: Failed to establish a new connection: [Errno 10060] A connection attempt failed because the connected party did not properly respond after a period of time or established connection failed because connected host has failed to respond',))
+# last_checked = Sun Aug 27 12:06:13 2017
 
-[http://www.circulartriangle.com/blog/?feed=atom&tag=python]
-name = Matt Wilkes
+# [http://www.circulartriangle.com/blog/?feed=atom&tag=python]
+# name = Matt Wilkes
+# notes = HTTPConnectionPool(host='www.circulartriangle.com', port=80): Max retries exceeded with url: /blog/?feed=atom&tag=python (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x03CACDD0>: Failed to establish a new connection: [Errno 10060] A connection attempt failed because the connected party did not properly respond after a period of time or established connection failed because connected host has failed to respond',))
+# last_checked = Sun Aug 27 12:06:34 2017
 
 [http://matthewrocklin.com/blog/feed.python.xml]
 name = Matthew Rocklin
+last_checked = Sun Aug 27 12:06:35 2017
 
 [http://www.stealthcopter.com/blog/tag/python/feed/]
 name = Matthew Rollings
+last_checked = Sun Aug 27 12:06:36 2017
 
 [http://blog.tplus1.com/index.php/category/python/feed]
 name = Matthew Wilson
+last_checked = Sun Aug 27 12:06:36 2017
 
 [http://copypasteprogrammer.blogspot.com/feeds/posts/default/-/python]
 name = Mattias Brändström
+last_checked = Sun Aug 27 12:06:37 2017
 
 [http://mauveweb.co.uk/rss.xml]
 name = Mauveweb
+last_checked = Sun Aug 27 12:06:37 2017
 
-[http://maxischenko.in.ua/planet_python/]
-name = Max Ischenko
+# [http://maxischenko.in.ua/planet_python/]
+# name = Max Ischenko
+# notes = HTTPConnectionPool(host='maxischenko.in.ua', port=80): Max retries exceeded with url: /planet_python/ (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x04069790>: Failed to establish a new connection: [Errno 11001] getaddrinfo failed',))
+# last_checked = Sun Aug 27 12:06:37 2017
 
 [http://blog.klymyshyn.com/feeds/posts/default/-/python]
 name = Max Klymyshyn
+last_checked = Sun Aug 27 12:06:37 2017
 
 [http://freshfoo.com/blog/index.atom]
 name = "Menno's Musings"
+last_checked = Sun Aug 27 12:06:38 2017
 
 [http://techspot.zzzeek.org/?feed=rss2]
 name = Michael Bayer
+last_checked = Sun Aug 27 12:06:39 2017
 
 [http://beckerfuffle.com/blog/categories/python/atom.xml]
 name = Michael Becker
+last_checked = Sun Aug 27 12:06:39 2017
 
-[http://mike.crute.org/blog/tag/python/feed]
-name = Michael Crute
+# [http://mike.crute.org/blog/tag/python/feed]
+# name = Michael Crute
+# notes = HTTPConnectionPool(host='mike.crute.org', port=80): Max retries exceeded with url: /blog/tag/python/feed (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x04070930>: Failed to establish a new connection: [Errno 11002] getaddrinfo failed',))
+# last_checked = Sun Aug 27 12:06:40 2017
 
 [http://mdboom.github.io/feeds/all.atom.xml]
 name = Michael Droettboom
+last_checked = Sun Aug 27 12:06:40 2017
 
 [http://feeds.feedburner.com/voidspace]
 name = Michael Foord
+last_checked = Sun Aug 27 12:06:41 2017
 
-[http://starship.python.net/crew/mwh/blog/nb.cgi/syndicate/weblog/python]
-name = Michael Hudson
+# [http://starship.python.net/crew/mwh/blog/nb.cgi/syndicate/weblog/python]
+# name = Michael Hudson
+# notes = 404 Client Error: Not Found for url: http://starship.python.net/crew/mwh/blog/nb.cgi/syndicate/weblog/python
+# last_checked = Sun Aug 27 12:06:41 2017
 
 [http://mjtokelly.blogspot.com/feeds/posts/default/-/Python]
 name = "Michael J.T. O'Kelly"
+last_checked = Sun Aug 27 12:06:41 2017
 
 [http://michaelmartinez.in/feeds/python.rss.xml]
 name = Michael Martinez
+last_checked = Sun Aug 27 12:06:41 2017
 
 [http://micknelson.wordpress.com/category/python/feed/atom/]
 name = Michael Nelson
+last_checked = Sun Aug 27 12:06:42 2017
 
 [http://michael.susens-schurter.com/blog/category/technology/python/feed]
 name = Michael Schurter
+last_checked = Sun Aug 27 12:06:43 2017
 
 [http://yeoldeclue.com/cgi-bin/blog/food.cgi]
 name = Michael Sparks
+last_checked = Sun Aug 27 12:06:43 2017
 
-[http://mikewatkins.ca/tags/python/feeds/atom]
-name = Michael Watkins
+# [http://mikewatkins.ca/tags/python/feeds/atom]
+# name = Michael Watkins
+# notes = 404 Client Error: Not Found for url: https://mikewatkins.ca/tags/python/feeds/atom
+# last_checked = Sun Aug 27 12:06:44 2017
 
 [http://mousebender.wordpress.com/feed/atom/]
 name = Michal Kwiatkowski
+last_checked = Sun Aug 27 12:06:44 2017
 
 [https://bultrowicz.com/blog/tag/python/atom.xml]
 name = Michał Bultrowicz
+last_checked = Sun Aug 27 12:06:45 2017
 
 [http://blog.mdomans.com/rss/python/]
 name = Michał Domański
+last_checked = Sun Aug 27 12:06:46 2017
 
 [http://www.artima.com/weblogs/feeds/bloggers/micheles.rss]
 name = Michele Simionato
+last_checked = Sun Aug 27 12:06:46 2017
 
 [http://www.firsttimeprogrammer.blogspot.com/feeds/posts/default/-/python?alt=rss]
 name = Michy Alice
+last_checked = Sun Aug 27 12:06:47 2017
 
 [http://blog.vrplumber.com/index.php?/feeds/categories/1-Snaking.rss]
 name = Mike C. Fletcher
+last_checked = Sun Aug 27 12:06:47 2017
 
 [http://www.blog.pythonlibrary.org/feed/]
 name = Mike Driscoll
+last_checked = Sun Aug 27 12:06:49 2017
 
 [http://python-academy.blogspot.com/feeds/posts/default]
 name = Mike Müller
+last_checked = Sun Aug 27 12:06:50 2017
 
-[http://mikenaberezny.com/category/python/?feed=rss]
-name = Mike Naberezny
+# [http://mikenaberezny.com/category/python/?feed=rss]
+# name = Mike Naberezny
+# notes = 404 Client Error: Not Found for url: http://mikenaberezny.com/category/python/?feed=rss
+# last_checked = Sun Aug 27 12:06:50 2017
 
-[http://www.pirnat.com/rss/exilejedi-python-rss.xml]
-name = Mike Pirnat
+# [http://www.pirnat.com/rss/exilejedi-python-rss.xml]
+# name = Mike Pirnat
+# notes = 404 Client Error: Not Found for url: http://www.pirnat.com/rss/exilejedi-python-rss.xml
+# last_checked = Sun Aug 27 12:06:50 2017
 
 [http://www.mikealrogers.com/archives/category/python/feed]
 name = Mikeal Rogers
+last_checked = Sun Aug 27 12:06:51 2017
 
 [http://kmike.ru/feeds/tags/planet-python.atom.xml]
 name = Mikhail Korobov
+last_checked = Sun Aug 27 12:06:51 2017
 
 [http://opensourcehacker.com/category/python/feed/]
 name = Mikko Ohtamaa
+last_checked = Sun Aug 27 12:06:53 2017
 
-[http://dmoonc.com/blog/?cat=24&feed=rss2]
-name = Mitch Chapman
+# [http://dmoonc.com/blog/?cat=24&feed=rss2]
+# name = Mitch Chapman
+# notes = 403 Client Error: Forbidden for url: http://dmoonc.com/blog/?cat=24&feed=rss2
+# last_checked = Sun Aug 27 12:06:53 2017
 
 [http://www.elastician.com/feeds/posts/default]
 name = Mitchell Garnaat
+last_checked = Sun Aug 27 12:06:54 2017
 
 [http://pythonbyexample.blogspot.com/feeds/posts/default/]
 name = Mitya Sirenef
+last_checked = Sun Aug 27 12:06:54 2017
 
 [http://montrealpython.com/feed/]
 name = Montreal Python User Group
+last_checked = Sun Aug 27 12:06:55 2017
 
 [http://blogologue.com/atom.xml?category=1470141490X3]
 name = "Morphex's Blogologue"
+last_checked = Sun Aug 27 12:06:55 2017
 
 [http://www.nidelven-it.no/weblogs/hosting/atom.xml?category=1334244339X02]
 name = Morten W Petersen
+last_checked = Sun Aug 27 12:06:56 2017
 
 [https://orbifold.xyz/feeds/all.atom.xml]
 name = Moshe Zadka
+last_checked = Sun Aug 27 12:06:56 2017
 
 [https://www.moyaproject.com/blog/feed/]
 name = Moya Project
+last_checked = Sun Aug 27 12:06:57 2017
 
 [http://blog.mozilla.com/webdev/category/python-2/feed/]
 name = Mozilla Web Development
+last_checked = Sun Aug 27 12:06:59 2017
 
 [http://muharem.wordpress.com/feed/atom/]
 name = Muharem Hrnjadovic
+last_checked = Sun Aug 27 12:07:00 2017
 
 [http://www.thesamet.com/blog/tags/python/rss]
 name = Nadav Samet
+last_checked = Sun Aug 27 12:07:01 2017
 
 [http://nadiana.com/category/python/feed]
 name = Nadia Alramli
+last_checked = Sun Aug 27 12:07:02 2017
 
 [http://learnpython.wordpress.com/feed/atom/]
 name = Naomi Ceder
+last_checked = Sun Aug 27 12:07:03 2017
 
 [http://www.natan.termitnjak.net/blog/category/python/feed/atom/index.xml]
 name = Natan Zabkar
+last_checked = Sun Aug 27 12:07:03 2017
 
-[http://climateecology.wordpress.com/tag/python/feed/]
-name = Nathan Lemoine
+# [http://climateecology.wordpress.com/tag/python/feed/]
+# name = Nathan Lemoine
+# notes = 410 Client Error: Gone for url: https://climateecology.wordpress.com/tag/python/feed/
+# last_checked = Sun Aug 27 12:07:04 2017
 
-[https://www.neckbeardrepublic.com/rss/]
-name = Neckbeard Republic
+# [https://www.neckbeardrepublic.com/rss/]
+# name = Neckbeard Republic
+# notes = HTTPSConnectionPool(host='www.neckbeardrepublic.com', port=443): Max retries exceeded with url: /rss/ (Caused by SSLError(CertificateError("hostname 'www.neckbeardrepublic.com' doesn't match either of '*.herokuapp.com', 'herokuapp.com'",),))
+# last_checked = Sun Aug 27 12:07:04 2017
 
 [http://nedbatchelder.com/blog/planetpython.xml]
 name = Ned Batchelder
+last_checked = Sun Aug 27 12:07:05 2017
 
 [http://python.ca/nas/log/rss-python.xml]
 name = Neil Schemenauer
+last_checked = Sun Aug 27 12:07:06 2017
 
-[http://sandbox.rulemaker.net/ngps/rdf10_python_xml]
-name = Ng Pheng Siong
+# [http://sandbox.rulemaker.net/ngps/rdf10_python_xml]
+# name = Ng Pheng Siong
+# notes = HTTPConnectionPool(host='sandbox.rulemaker.net', port=80): Max retries exceeded with url: /ngps/rdf10_python_xml (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x03CAC710>: Failed to establish a new connection: [Errno 10060] A connection attempt failed because the connected party did not properly respond after a period of time or established connection failed because connected host has failed to respond',))
+# last_checked = Sun Aug 27 12:07:27 2017
 
 [http://blog.alienretro.com/category/python-en-2/feed/]
 name = Nicholas Amorim
+last_checked = Sun Aug 27 12:07:28 2017
 
-[http://nichol.as/tags/python/feed]
-name = Nicholas Piël
+# [http://nichol.as/tags/python/feed]
+# name = Nicholas Piël
+# notes = 404 Client Error: Not Found for url: http://nichol.as/tags/python/feed
+# last_checked = Sun Aug 27 12:07:28 2017
 
 [http://www.curiousefficiency.org/categories/python.xml]
 name = Nick Coghlan
+last_checked = Sun Aug 27 12:07:29 2017
 
 [http://www.craig-wood.com/nick/articles/category/python/feed/atom/index.xml]
 name = Nick Craig-Wood
+last_checked = Sun Aug 27 12:07:29 2017
 
 [http://blog.efford.org/tag/feeds/python.atom.xml]
 name = Nick Efford
+last_checked = Sun Aug 27 12:07:29 2017
 
 [http://nickjanetakis.blogspot.com/feeds/posts/default/-/python]
 name = Nick Janetakis
+last_checked = Sun Aug 27 12:07:29 2017
 
 [http://nicolaiarocci.com/tags/python/index.xml]
 name = Nicola Iarocci
+last_checked = Sun Aug 27 12:07:30 2017
 
 [http://nicdumz.fr/blog/category/python/feed/index.xml]
 name = Nicolas Dumazet
+last_checked = Sun Aug 27 12:07:30 2017
 
-[http://www.nicosphere.net/tag/python-en/feed/]
-name = Nicolas Paris
+# [http://www.nicosphere.net/tag/python-en/feed/]
+# name = Nicolas Paris
+# notes = 508 Server Error: Loop Detected for url: http://www.nicosphere.net/tag/python-en/feed/
+# last_checked = Sun Aug 27 12:07:30 2017
 
 [http://nigelb.me/python.xml]
 name = Nigel Babu
+last_checked = Sun Aug 27 12:07:31 2017
 
-[http://www.nikhilgopal.com/feeds/posts/default/-/python]
-name = Nikhil Gopal
+# [http://www.nikhilgopal.com/feeds/posts/default/-/python]
+# name = Nikhil Gopal
+# notes = 404 Client Error: Not Found for url: https://nikhilgopal.com/feeds/posts/default/-/python
+# last_checked = Sun Aug 27 12:07:32 2017
 
 [http://feeds.feedburner.com/getnikola/QBjz]
 name = Nikola
+last_checked = Sun Aug 27 12:07:32 2017
 
-[http://artificialcode.blogspot.com/feeds/posts/default/-/python]
-name = Noah Gift
+# [http://artificialcode.blogspot.com/feeds/posts/default/-/python]
+# name = Noah Gift
+# notes = 404 Client Error: Not Found for url: http://artificialcode.blogspot.com/feeds/posts/default/-/python
+# last_checked = Sun Aug 27 12:07:33 2017
 
-[http://www.numfocus.org/1/feed]
-name = NumFOCUS
+# [http://www.numfocus.org/1/feed]
+# name = NumFOCUS
+# notes = 403 Client Error: Forbidden for url: http://www.numfocus.org/1/feed
+# last_checked = Sun Aug 27 12:07:33 2017
 
 [http://www.obeythetestinggoat.com/feeds/all.atom.xml]
 name = Obey the Testing Goat
+last_checked = Sun Aug 27 12:07:33 2017
 
 [https://andrich.blog/tag/python/feed/]
 name = Oliver Andrich
+last_checked = Sun Aug 27 12:07:34 2017
 
 [http://www.omahapython.org/blog/feed]
 name = Omaha Python Users Group
+last_checked = Sun Aug 27 12:07:35 2017
 
-[http://omar.toomuchcookies.net/node/category/programming/python/feed/]
-name = Omar Abo-Namous
+# [http://omar.toomuchcookies.net/node/category/programming/python/feed/]
+# name = Omar Abo-Namous
+# notes = 404 Client Error: Not Found for url: http://omar.toomuchcookies.net/node/category/programming/python/feed/
+# last_checked = Sun Aug 27 12:07:35 2017
 
 [http://ondrejcertik.blogspot.com/feeds/posts/default/-/python]
 name = Ond&#345;ej &#268;ert&iacute;k
+last_checked = Sun Aug 27 12:07:35 2017
 
-[http://openhatch.org/blog/tag/python/feed/atom/]
-name = OpenHatch Python posts
+# [http://openhatch.org/blog/tag/python/feed/atom/]
+# name = OpenHatch Python posts
+# notes = 500 Server Error: INTERNAL SERVER ERROR for url: http://openhatch.org/blog/tag/python/feed/atom/
+# last_checked = Sun Aug 27 12:07:36 2017
 
-[http://orestis.gr/feeds/tag/python/en/]
-name = Orestis Markou
+# [http://orestis.gr/feeds/tag/python/en/]
+# name = Orestis Markou
+# notes = 404 Client Error: Not Found for url: https://orestis.gr/feeds/tag/python/en/
+# last_checked = Sun Aug 27 12:07:36 2017
 
 [http://blog.partecs.com/category/python/feed]
 name = Partecs
+last_checked = Sun Aug 27 12:07:37 2017
 
 [http://s3.amazonaws.com/blog.pathwright.com/feeds/tag.Python.atom.xml]
 name = Pathwright
+last_checked = Sun Aug 27 12:07:37 2017
 
 [http://weblog.patrice.ch/tags/Python.atom]
 name = Patrice Neff
+last_checked = Sun Aug 27 12:07:38 2017
 
 [http://pp.com.mx/blog/topics/python/feed/atom/]
 name = Patricio Paez
+last_checked = Sun Aug 27 12:07:38 2017
 
 [http://www.patricksoftwareblog.com/tag/python/feed/]
 name = Patrick Kennedy
+last_checked = Sun Aug 27 12:07:40 2017
 
 [http://pkaudio.blogspot.com/feeds/posts/default/-/python]
 name = Patrick Stinson
+last_checked = Sun Aug 27 12:07:40 2017
 
 [http://news.e-scribe.com/feeds/tag/python/atom.xml]
 name = Paul Bissex
+last_checked = Sun Aug 27 12:07:44 2017
 
 [http://pauleveritt.wordpress.com/feed/atom/]
 name = Paul Everitt
+last_checked = Sun Aug 27 12:07:45 2017
 
 [http://www.logarithmic.net/pfh?action=atom;hasname=1;name=gcgmgpghfpgdgpgegf]
 name = Paul Harrison
+last_checked = Sun Aug 27 12:07:46 2017
 
 [http://codebright.wordpress.com/category/python/feed/atom/]
 name = Paul Redman
+last_checked = Sun Aug 27 12:07:46 2017
 
-[http://python.genedrift.org/feed/]
-name = Paulo Nuin
+# [http://python.genedrift.org/feed/]
+# name = Paulo Nuin
+# notes = 404 Client Error: Not Found for url: http://python.genedrift.org/feed/
+# last_checked = Sun Aug 27 12:07:47 2017
 
 [http://pfertyk.me/feeds/python.atom.xml]
 name = Paweł Fertyk
+last_checked = Sun Aug 27 12:07:47 2017
 
 [https://www.paypal-engineering.com/tag/python/feed/]
 name = PayPal Engineering Blog
+last_checked = Sun Aug 27 12:07:49 2017
 
 [http://pedrokroger.net/category/python/feed/]
 name = Pedro Kroger
+last_checked = Sun Aug 27 12:07:51 2017
 
 [http://pedro.valelima.com/blog/feed/tag/python/]
 name = Pedro Lima
+last_checked = Sun Aug 27 12:07:52 2017
 
 [http://www.petehunt.net/blog/?feed=rss2]
 name = Pete Hunt
+last_checked = Sun Aug 27 12:07:52 2017
 
 [https://wearpants.org/feeds/petecode.xml?tag=python]
 name = Petecode
+last_checked = Sun Aug 27 12:07:52 2017
 
 [http://www.peterbe.com/oc-Python/rss.xml]
 name = Peter Bengtsson
+last_checked = Sun Aug 27 12:07:53 2017
 
 [http://petereisentraut.blogspot.com/feeds/posts/default/-/Python/]
 name = Peter Eisentraut
+last_checked = Sun Aug 27 12:07:53 2017
 
 [http://neovox.advancedmagic.de/?feed=rss2&cat=6]
 name = Peter Fankhänel
+last_checked = Sun Aug 27 12:07:54 2017
 
 [http://www.excelsiorsystems.net/blog/feeds/tags/Python/]
 name = Peter Halliday
+last_checked = Sun Aug 27 12:07:55 2017
 
 [http://push.cx/tag/python/feed]
 name = Peter Harkins
+last_checked = Sun Aug 27 12:07:57 2017
 
 [http://peter-hoffmann.com/feed/atom-python.xml]
 name = Peter Hoffmann
+last_checked = Sun Aug 27 12:07:57 2017
 
-[http://mindtrove.info/tag/python/feed/index.xml]
-name = Peter Parente
+# [http://mindtrove.info/tag/python/feed/index.xml]
+# name = Peter Parente
+# notes = 404 Client Error: Not Found for url: http://mindtrove.info/tag/python/feed/index.xml
+# last_checked = Sun Aug 27 12:07:58 2017
 
-[http://petro.tanrei.ca/categories/python/feed.atom]
-name = Petro Verkhogliad
+# [http://petro.tanrei.ca/categories/python/feed.atom]
+# name = Petro Verkhogliad
+# notes = 404 Client Error: Not Found for url: http://petro.tanrei.ca/categories/python/feed.atom
+# last_checked = Sun Aug 27 12:07:58 2017
 
 [http://www.philhassey.com/blog/category/python/feed]
 name = Phil Hassey
+last_checked = Sun Aug 27 12:07:59 2017
 
 [http://dunderboss.blogspot.com/feeds/posts/default/-/python]
 name = Philip Jenvey
+last_checked = Sun Aug 27 12:07:59 2017
 
 [http://blog.pyspoken.com/feed/atom/]
 name = Philip Semanchuk
+last_checked = Sun Aug 27 12:08:00 2017
 
 [http://philikon.wordpress.com/category/python/feed/atom/]
 name = Philipp von Weitershausen
+last_checked = Sun Aug 27 12:08:01 2017
 
 [http://base-art.net/Articles/rss.xml]
 name = Philippe Normand
+last_checked = Sun Aug 27 12:08:01 2017
 
 [http://feeds.feedburner.com/pje-on-programming]
 name = Phillip J. Eby
+last_checked = Sun Aug 27 12:08:01 2017
 
 [http://sites.google.com/site/pydatalog/pypl/python-blog/posts.xml]
 name = Pierre Carbonnelle
+last_checked = Sun Aug 27 12:08:01 2017
 
-[http://mancoosi.org/~abate/taxonomy/term/56/0/feed]
-name = Pietro Abate
+# [http://mancoosi.org/~abate/taxonomy/term/56/0/feed]
+# name = Pietro Abate
+# notes = HTTPConnectionPool(host='mancoosi.org', port=80): Max retries exceeded with url: /~abate/taxonomy/term/56/0/feed (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x03CD07D0>: Failed to establish a new connection: [Errno 10060] A connection attempt failed because the connected party did not properly respond after a period of time or established connection failed because connected host has failed to respond',))
+# last_checked = Sun Aug 27 12:08:22 2017
 
 [https://www.podcastinit.com/feed/mp3/]
 name = Podcast.__init__
+last_checked = Sun Aug 27 12:08:24 2017
 
 [http://polyglot.ninja/category/python/feed/]
 name = Polyglot.Ninja()
+last_checked = Sun Aug 27 12:08:25 2017
 
 [https://ironboundsoftware.com/blog/category/python/feed/]
 name = Possbility and Probability
+last_checked = Sun Aug 27 12:08:27 2017
 
 [http://feeds.feedburner.com/btbytes_python]
 name = Pradeep Gowda
+last_checked = Sun Aug 27 12:08:28 2017
 
 [http://www.flicker-technical.blogspot.fr/feeds/posts/default/-/Python]
 name = Pranav Pandey
+last_checked = Sun Aug 27 12:08:28 2017
 
 [http://feeds.feedburner.com/shutupandship_python]
 name = Praveen Gollakota
+last_checked = Sun Aug 27 12:08:28 2017
 
 [http://programandociencia.com/category/english/feed/]
 name = Programando Ciência
+last_checked = Sun Aug 27 12:08:29 2017
 
 [https://www.programiz.com/python-programming/rss.xml]
 name = Programiz
+last_checked = Sun Aug 27 12:08:30 2017
 
 [https://programmingideaswithjake.wordpress.com/category/python/feed/rdf/]
 name = Programming Ideas With Jake
+last_checked = Sun Aug 27 12:08:30 2017
 
-[https://eshlox.net/tag/python/rss/index.xml]
-name = Przemysław Kołodziejczyk
+# [https://eshlox.net/tag/python/rss/index.xml]
+# name = Przemysław Kołodziejczyk
+# notes = 404 Client Error: Not Found for url: https://eshlox.net/tag/python/rss/index.xml/
+# last_checked = Sun Aug 27 12:08:30 2017
 
-[http://blog.pyamf.org/feed]
-name = PyAMF Blog
+# [http://blog.pyamf.org/feed]
+# name = PyAMF Blog
+# notes = 404 Client Error: Not Found for url: http://blog.pyamf.org/feed
+# last_checked = Sun Aug 27 12:08:31 2017
 
 [https://pybit.es/feeds/all.rss.xml]
 name = PyBites
+last_checked = Sun Aug 27 12:08:32 2017
 
-[http://blog.pycarolinas.org/rss/]
-name = PyCarolinas
+# [http://blog.pycarolinas.org/rss/]
+# name = PyCarolinas
+# notes = 404 Client Error: Not Found for url: http://blog.pycarolinas.org/rss/
+# last_checked = Sun Aug 27 12:08:32 2017
 
 [http://feeds.feedburner.com/Pycharm]
 name = PyCharm
+last_checked = Sun Aug 27 12:08:32 2017
 
 [http://feeds.feedburner.com/PyCon]
 name = PyCon
+last_checked = Sun Aug 27 12:08:33 2017
 
-[http://www.youtube.com/rss/user/pycon08/videos.rss]
-name = PyCon 2008 on YouTube
+# [http://www.youtube.com/rss/user/pycon08/videos.rss]
+# name = PyCon 2008 on YouTube
+# notes = 404 Client Error: Not Found for url: https://www.youtube.com/rss/user/pycon08/videos.rss
+# last_checked = Sun Aug 27 12:08:33 2017
 
 [https://2016.pycon-au.org/media/news/rss]
 name = PyCon Australia
+last_checked = Sun Aug 27 12:08:35 2017
 
-[http://pl.pycon.org/2015/en/rss-aktualnosci]
-name = PyCon PL Conference
+# [http://pl.pycon.org/2015/en/rss-aktualnosci]
+# name = PyCon PL Conference
+# notes = 404 Client Error: Not Found for url: https://pl.pycon.org/2015/en/rss-aktualnosci
+# last_checked = Sun Aug 27 12:08:35 2017
 
 [http://advocacy.python.org/podcasts/pycon.rss]
 name = PyCon Podcast
+last_checked = Sun Aug 27 12:08:35 2017
 
-[http://pyladies.com/blog/feeds/atom/]
-name = PyLadies
+# [http://pyladies.com/blog/feeds/atom/]
+# name = PyLadies
+# notes = 404 Client Error: Not Found for url: http://www.pyladies.com/blog/feeds/atom/
+# last_checked = Sun Aug 27 12:08:36 2017
 
 [http://morepypy.blogspot.com/feeds/posts/default]
 name = PyPy Development
+last_checked = Sun Aug 27 12:08:36 2017
 
 [http://pytennessee.tumblr.com/rss]
 name = PyTennessee
+last_checked = Sun Aug 27 12:08:37 2017
 
 [https://www.pytexas.org/blog.rss]
 name = PyTexas
+last_checked = Sun Aug 27 12:08:38 2017
 
-[http://pylonshq.com/articles.atom]
-name = Pylons News Feed
+# [http://pylonshq.com/articles.atom]
+# name = Pylons News Feed
+# notes = 404 Client Error: Not Found for url: http://pylonshq.com/articles.atom
+# last_checked = Sun Aug 27 12:08:39 2017
 
 [http://feeds.feedburner.com/pypix]
 name = Pypix
+last_checked = Sun Aug 27 12:08:39 2017
 
 [http://python4kids.wordpress.com/feed/atom/]
 name = Python 4 Kids
+last_checked = Sun Aug 27 12:08:40 2017
 
-[http://www.awaretek.com/python/index.xml]
-name = Python 411 Podcast
+# [http://www.awaretek.com/python/index.xml]
+# name = Python 411 Podcast
+# notes = 404 Client Error: Not Found for url: http://www.awaretek.com/python/index.xml
+# last_checked = Sun Aug 27 12:08:40 2017
 
 [http://python-advocacy.blogspot.com/atom.xml]
 name = Python Advocacy
+last_checked = Sun Aug 27 12:08:41 2017
 
 [http://blog.pythonanywhere.com/feed/]
 name = Python Anywhere
+last_checked = Sun Aug 27 12:08:41 2017
 
 [https://pythonbytes.fm/episodes/rss]
 name = Python Bytes
+last_checked = Sun Aug 27 12:08:43 2017
 
 [http://pythondata.com/feed/]
 name = Python Data
+last_checked = Sun Aug 27 12:08:43 2017
 
 [http://www.pythondiary.com/blog.xml]
 name = Python Diary
+last_checked = Sun Aug 27 12:08:44 2017
 
 [http://pythondoeswhat.blogspot.com/feeds/posts/default]
 name = Python Does What?!
+last_checked = Sun Aug 27 12:08:45 2017
 
 [https://blogs.msdn.microsoft.com/pythonengineering/feed/]
 name = Python Engineering at Microsoft
+last_checked = Sun Aug 27 12:08:45 2017
 
 [http://feeds.feedburner.com/PythonInsider]
 name = Python Insider
+last_checked = Sun Aug 27 12:08:45 2017
 
-[http://www.python.org/channews.rdf]
-name = Python News
+# [http://www.python.org/channews.rdf]
+# name = Python News
+# notes = 404 Client Error: OK for url: https://www.python.org/channews.rdf
+# last_checked = Sun Aug 27 12:08:46 2017
 
-[http://python-open-mike.posterous.com/rss.xml]
-name = Python Open Mike
+# [http://python-open-mike.posterous.com/rss.xml]
+# name = Python Open Mike
+# notes = 503 Server Error: Service Unavailable for url: http://python-open-mike.posterous.com/rss.xml
+# last_checked = Sun Aug 27 12:08:51 2017
 
 [http://www.pyptug.org/feeds/posts/default/]
 name = Python Piedmont Triad User Group
+last_checked = Sun Aug 27 12:08:51 2017
 
 [http://pyfound.blogspot.com/atom.xml]
 name = Python Software Foundation
+last_checked = Sun Aug 27 12:08:52 2017
 
-[http://pythonsprints.com/feeds/latest/]
-name = Python Sprints
+# [http://pythonsprints.com/feeds/latest/]
+# name = Python Sprints
+# notes = HTTPConnectionPool(host='pythonsprints.com', port=80): Max retries exceeded with url: /feeds/latest/ (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x03CC95D0>: Failed to establish a new connection: [Errno 11002] getaddrinfo failed',))
+# last_checked = Sun Aug 27 12:08:52 2017
 
 [http://pythonsweetness.tumblr.com/rss]
 name = Python Sweetness
+last_checked = Sun Aug 27 12:08:52 2017
 
-[http://pythontestingcookbook.posterous.com/rss.xml]
-name = Python Testing Cookbook
+# [http://pythontestingcookbook.posterous.com/rss.xml]
+# name = Python Testing Cookbook
+# notes = 503 Server Error: Service Unavailable for url: http://pythontestingcookbook.posterous.com/rss.xml
+# last_checked = Sun Aug 27 12:08:57 2017
 
 [http://python-groups.blogspot.com/feeds/posts/default]
 name = Python User Groups
+last_checked = Sun Aug 27 12:08:58 2017
 
-[http://pythonforbiologists.com/index.php/category/python/feed/]
-name = Python for biologists
+# [http://pythonforbiologists.com/index.php/category/python/feed/]
+# name = Python for biologists
+# notes = 404 Client Error: Not Found for url: https://pythonforbiologists.com/index.php/category/python/feed/
+# last_checked = Sun Aug 27 12:08:59 2017
 
 [http://python-karan.blogspot.in//feeds/posts/default]
 name = Python on Karan
+last_checked = Sun Aug 27 12:08:59 2017
 
 [http://developerblog.myo.com/tag/python/rss/]
 name = Python with Myo
+last_checked = Sun Aug 27 12:08:59 2017
 
 [http://pythonxynews.blogspot.com/feeds/posts/default]
 name = Python(x,y) News
+last_checked = Sun Aug 27 12:08:59 2017
 
 [http://pythonclub.com.br/feeds/all.atom.xml]
 name = PythonClub - A Brazilian collaborative blog about Python
+last_checked = Sun Aug 27 12:09:01 2017
 
 [http://www.pythonthreads.com/index2.php?option=com_rss&feed=RSS2.0&no_html=1]
 name = PythonThreads
+last_checked = Sun Aug 27 12:09:02 2017
 
 [http://pythonology.blogspot.com/atom.xml]
 name = Pythonology
+last_checked = Sun Aug 27 12:09:02 2017
 
 [http://ptspts.blogspot.com/feeds/posts/default/-/planet-python]
 name = Péter Szabó
+last_checked = Sun Aug 27 12:09:03 2017
 
 [http://blog.zsoldosp.eu/category/python/feed/]
 name = Péter Zsoldos
+last_checked = Sun Aug 27 12:09:03 2017
 
 [http://www.bitdance.com/blog/rss.xml]
 name = R David Murray
+last_checked = Sun Aug 27 12:09:03 2017
 
 [http://threebean.org/blog/category/python/feed/atom/index.xml]
 name = Ralph Bean
+last_checked = Sun Aug 27 12:09:04 2017
 
 [http://www.ralph-heinkel.com/blog/category/python/feed/atom/index.xml]
 name = Ralph Heinkel
+last_checked = Sun Aug 27 12:09:04 2017
 
 [http://feeds.feedburner.com/RamRachumsBlog/planetpython]
 name = Ram Rachum
+last_checked = Sun Aug 27 12:09:04 2017
 
-[http://blog.sramana.in/rss.xml?tag=python]
-name = Ramana
+# [http://blog.sramana.in/rss.xml?tag=python]
+# name = Ramana
+# notes = HTTPConnectionPool(host='blog.sramana.in', port=80): Max retries exceeded with url: /rss.xml?tag=python (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x03A98130>: Failed to establish a new connection: [Errno 11001] getaddrinfo failed',))
+# last_checked = Sun Aug 27 12:09:04 2017
 
 [http://blog.randell.ph/tag/python/feed/atom/]
 name = Randell Benavidez
+last_checked = Sun Aug 27 12:09:07 2017
 
 [http://randlet.com/blog/python/rss.xml]
 name = Randle Taylor
+last_checked = Sun Aug 27 12:09:07 2017
 
-[http://randyzwitch.com/tag/python/feed/]
-name = Randy Zwitch
+# [http://randyzwitch.com/tag/python/feed/]
+# name = Randy Zwitch
+# notes = 404 Client Error: Not Found for url: http://randyzwitch.com/tag/python/feed/
+# last_checked = Sun Aug 27 12:09:07 2017
 
 [http://rhettinger.wordpress.com/feed/atom/]
 name = Raymond Hettinger
+last_checked = Sun Aug 27 12:09:08 2017
 
 [http://rayli.net/blog/tag/planetpython/feed/]
 name = Raymond Li
+last_checked = Sun Aug 27 12:09:10 2017
 
 [http://reachtim.com/feeds/python.atom.xml]
 name = Reach Tim
+last_checked = Sun Aug 27 12:09:11 2017
 
 [https://realpython.com/atom.xml]
 name = Real Python
+last_checked = Sun Aug 27 12:09:14 2017
 
 [http://reinout.vanrees.org/weblog/plonefeed.xml]
 name = Reinout van Rees
+last_checked = Sun Aug 27 12:09:14 2017
 
 [http://renesd.blogspot.com/feeds/posts/default/-/python]
 name = Rene Dudfield
+last_checked = Sun Aug 27 12:09:14 2017
 
 [http://blog.lerner.co.il/category/python/feed/]
 name = Reuven Lerner
+last_checked = Sun Aug 27 12:09:15 2017
 
 [http://rgomes-info.blogspot.co.uk/feeds/posts/default/-/python]
 name = Richard Gomes
+last_checked = Sun Aug 27 12:09:16 2017
 
 [http://www.mechanicalcat.net/richard/log/Python/rss]
 name = Richard Jones
+last_checked = Sun Aug 27 12:09:16 2017
 
 [http://posted-stuff.blogspot.com/feeds/posts/default/-/python]
 name = Richard Tew
+last_checked = Sun Aug 27 12:09:17 2017
 
 [http://blog.the-moon.net/feeds/posts/default/-/python]
 name = Richard Wall
+last_checked = Sun Aug 27 12:09:17 2017
 
 [http://blog.cakebread.info/feeds/posts/default/-/python]
 name = Rob Cakebread
+last_checked = Sun Aug 27 12:09:17 2017
 
 [http://www.robg3d.com/?tag=python&feed=atom]
 name = Rob Galanakis
+last_checked = Sun Aug 27 12:09:19 2017
 
-[http://www.robgolding.com/feed/?tag=python]
-name = Rob Golding
+# [http://www.robgolding.com/feed/?tag=python]
+# name = Rob Golding
+# notes = 403 Client Error: Forbidden for url: http://www.robgolding.com/feed/?tag=python
+# last_checked = Sun Aug 27 12:09:19 2017
 
-[http://blog.nonsequitarian.org/feeds/tags/planetpython/]
-name = Rob Miller
+# [http://blog.nonsequitarian.org/feeds/tags/planetpython/]
+# name = Rob Miller
+# notes = HTTPConnectionPool(host='blog.nonsequitarian.org', port=80): Max retries exceeded with url: /feeds/tags/planetpython/ (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x03CD0D10>: Failed to establish a new connection: [Errno 10060] A connection attempt failed because the connected party did not properly respond after a period of time or established connection failed because connected host has failed to respond',))
+# last_checked = Sun Aug 27 12:09:40 2017
 
 [http://www.aminus.org/blogs/xmlsrv/rss2.php?blog=2&cat=15]
 name = Robert Brewer
+last_checked = Sun Aug 27 12:09:41 2017
 
 [http://rbtcollins.wordpress.com/tag/python/feed/atom/]
 name = Robert Collins
+last_checked = Sun Aug 27 12:09:42 2017
 
-[http://robert-lujo.com/tagged/python/rss]
-name = Robert Lujo
+# [http://robert-lujo.com/tagged/python/rss]
+# name = Robert Lujo
+# notes = 404 Client Error: Not Found for url: http://robert-lujo.com/tagged/python/rss
+# last_checked = Sun Aug 27 12:09:43 2017
 
-[http://robert.io/blog/categories/python/atom.xml]
-name = Robert Picard
+# [http://robert.io/blog/categories/python/atom.xml]
+# name = Robert Picard
+# notes = 404 Client Error: Not Found for url: https://robert.io/blog/categories/python/atom.xml
+# last_checked = Sun Aug 27 12:09:44 2017
 
 [http://rz.scale-it.pl/rss-python.html]
 name = Robert Zaremba
+last_checked = Sun Aug 27 12:09:44 2017
 
 [http://feeds.feedburner.com/LateralOpinionpython]
 name = Roberto Alsina
+last_checked = Sun Aug 27 12:09:44 2017
 
-[http://wxPython.org/blog/feed/]
-name = Robin Dunn
+# [http://wxPython.org/blog/feed/]
+# name = Robin Dunn
+# notes = 404 Client Error: Not Found for url: https://wxpython.org/blog/feed/
+# last_checked = Sun Aug 27 12:09:45 2017
 
 [http://www.theatreofnoise.com/feeds/posts/default/-/dev]
 name = Robin Parmar
+last_checked = Sun Aug 27 12:09:45 2017
 
 [http://blog.rtwilson.com/category/programming-2/python/feed/]
 name = Robin Wilson
+last_checked = Sun Aug 27 12:09:47 2017
 
 [http://www.upfrontsystems.co.za/Members/roche/where-im-calling-from/RSS]
 name = Roche Compaan
+last_checked = Sun Aug 27 12:09:48 2017
 
 [http://www.serverzen.net/feeds/posts/default/-/python]
 name = Rocky Burt
+last_checked = Sun Aug 27 12:09:49 2017
 
 [http://linil.wordpress.com/feed/atom/]
 name = Rodrigo Araúj
+last_checked = Sun Aug 27 12:09:49 2017
 
-[http://garbas.si/blog/category/latest-python/RSS]
-name = Rok Garbas
+# [http://garbas.si/blog/category/latest-python/RSS]
+# name = Rok Garbas
+# notes = 404 Client Error: Not Found for url: https://garbas.si/blog/category/latest-python/RSS
+# last_checked = Sun Aug 27 12:09:49 2017
 
 [http://www.imankulov.name/categories/python.xml]
 name = Roman Imankulov
+last_checked = Sun Aug 27 12:09:50 2017
 
 [https://www.rosehosting.com/blog/tag/python/feed/]
 name = RoseHosting Blog
+last_checked = Sun Aug 27 12:09:51 2017
 
 [http://ruslanspivak.com/category/python/feed/atom/]
 name = Ruslan Spivak
+last_checked = Sun Aug 27 12:09:52 2017
 
 [http://www.asciiarmor.com/tagged/python/rss]
 name = Ryan Cox
+last_checked = Sun Aug 27 12:09:53 2017
 
-[http://naeblis.cx/rtomayko/weblog/python/index.rdf]
-name = Ryan Tomayko
+# [http://naeblis.cx/rtomayko/weblog/python/index.rdf]
+# name = Ryan Tomayko
+# notes = 404 Client Error: Not Found for url: http://naeblis.cx/rtomayko/weblog/python/index.rdf
+# last_checked = Sun Aug 27 12:09:53 2017
 
 [http://slott-softwarearchitect.blogspot.com/feeds/posts/default/-/python]
 name = S. Lott
+last_checked = Sun Aug 27 12:09:53 2017
 
 [https://pyhelper.wordpress.com/feed/]
 name = S. R. Krishnan
+last_checked = Sun Aug 27 12:09:54 2017
 
 [http://www.sdjournal.com/archives/categories/languages/python/rss.xml]
 name = SDJournal
+last_checked = Sun Aug 27 12:09:54 2017
 
 [http://pythonide.blogspot.com/feeds/posts/default]
 name = SPE Weblog
+last_checked = Sun Aug 27 12:09:55 2017
 
-[http://blog.stxnext.com/feeds/python.atom.xml]
-name = STX Next
+# [http://blog.stxnext.com/feeds/python.atom.xml]
+# name = STX Next
+# notes = 404 Client Error: Not Found for url: https://stxnext.com/blog/feeds/python.atom.xml/
+# last_checked = Sun Aug 27 12:09:56 2017
 
 [http://feeds.feedburner.com/sfpy]
 name = Salim Fadhley
+last_checked = Sun Aug 27 12:09:56 2017
 
 [http://bitshaq.com/tag/python/feed/atom/]
 name = Salman Haq
+last_checked = Sun Aug 27 12:09:57 2017
 
 [http://ssutch.org/tag/python/feed]
 name = Samuel Sutch
+last_checked = Sun Aug 27 12:09:57 2017
 
 [https://sandipanweb.wordpress.com/category/python/feed/]
 name = Sandipan Dey
+last_checked = Sun Aug 27 12:09:59 2017
 
 [http://sandrotosi.blogspot.com/feeds/posts/default/-/Python]
 name = Sandro Tosi
+last_checked = Sun Aug 27 12:09:59 2017
 
 [https://sayanchowdhury.dgplug.org/tags/planet/]
 name = Sayan Chowdhury
+last_checked = Sun Aug 27 12:10:00 2017
 
-[http://python.scripting.com/xml/rss.xml]
-name = Scripting the web with Python
+# [http://python.scripting.com/xml/rss.xml]
+# name = Scripting the web with Python
+# notes = HTTPConnectionPool(host='python.scripting.com', port=80): Max retries exceeded with url: /xml/rss.xml (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x03CD0AD0>: Failed to establish a new connection: [Errno 10060] A connection attempt failed because the connected party did not properly respond after a period of time or established connection failed because connected host has failed to respond',))
+# last_checked = Sun Aug 27 12:10:21 2017
 
 [http://seanmcgrath.blogspot.com/feeds/posts/default/-/python]
 name = Sean McGrath
+last_checked = Sun Aug 27 12:10:22 2017
 
-[http://www.tummy.com/journals/users/jafo/rss-python.xml]
-name = Sean Reifschneider
+# [http://www.tummy.com/journals/users/jafo/rss-python.xml]
+# name = Sean Reifschneider
+# notes = 404 Client Error: Not Found for url: https://www.tummy.com/journals/users/jafo/rss-python.xml
+# last_checked = Sun Aug 27 12:10:23 2017
 
 [http://www.chesnok.com/daily/category/python/feed/]
 name = Selena Deckelmann
+last_checked = Sun Aug 27 12:10:24 2017
 
 [https://semaphoreci.com/community/tags/python.atom]
 name = Semaphore Community
+last_checked = Sun Aug 27 12:10:26 2017
 
 [http://feeds.feedburner.com/phoe6pythonfeeds]
 name = Senthil Kumaran
+last_checked = Sun Aug 27 12:10:26 2017
 
-[http://blog.serverdensity.com/category/python/feed/]
-name = Server Density
+# [http://blog.serverdensity.com/category/python/feed/]
+# name = Server Density
+# notes = 403 Client Error: Forbidden for url: http://blog.serverdensity.com/category/python/feed/
+# last_checked = Sun Aug 27 12:10:26 2017
 
 [http://jjinux.blogspot.com/feeds/posts/default/-/python]
 name = Shannon -jj Behrens
+last_checked = Sun Aug 27 12:10:27 2017
 
 [http://shiningpanda.com/feeds/all.atom.xml]
 name = ShiningPanda
+last_checked = Sun Aug 27 12:10:28 2017
 
 [https://tech.shopkick.com/tagged/python/atom.xml]
 name = Shopkick Tech Blog
+last_checked = Sun Aug 27 12:10:29 2017
 
-[http://shriphani.com/blog/category/python/feed]
-name = Shriphani Palakodety
+# [http://shriphani.com/blog/category/python/feed]
+# name = Shriphani Palakodety
+# notes = 404 Client Error: Not Found for url: http://shriphani.com/blog/category/python/feed
+# last_checked = Sun Aug 27 12:10:29 2017
 
 [http://simeonfranklin.com/feeds/python/]
 name = Simeon Franklin
+last_checked = Sun Aug 27 12:10:30 2017
 
 [http://feeds.feedburner.com/simeon_visser_python]
 name = Simeon Visser
+last_checked = Sun Aug 27 12:10:31 2017
 
 [http://aboutsimon.com/category/python/feed/atom/]
 name = Simon
+last_checked = Sun Aug 27 12:10:32 2017
 
 [http://www.brunningonline.net/simon/blog/index-P.xml]
 name = Simon Brunning
+last_checked = Sun Aug 27 12:10:32 2017
 
-[http://simonwillison.net/atom/tagged/python/]
-name = Simon Willison
+# [http://simonwillison.net/atom/tagged/python/]
+# name = Simon Willison
+# notes = 404 Client Error: Not Found for url: http://blog.simonwillison.net//atom/tagged/python/
+# last_checked = Sun Aug 27 12:10:34 2017
 
 [http://entitycrisis.blogspot.com/feeds/posts/default/-/Python]
 name = Simon Wittber
+last_checked = Sun Aug 27 12:10:34 2017
 
 [https://simpleisbetterthancomplex.com/feed.xml]
 name = Simple is Better Than Complex
+last_checked = Sun Aug 27 12:10:37 2017
 
 [http://www.softformance.com/feed/?tag=python]
 name = SoftFormance
+last_checked = Sun Aug 27 12:10:38 2017
 
 [http://speno.blogspot.com/atom.xml]
 name = "Speno's Pythonic Avocado"
+last_checked = Sun Aug 27 12:10:39 2017
 
 [http://spikeekips.tumblr.com/tagged/python/rss]
 name = Spike ekipS
+last_checked = Sun Aug 27 12:10:39 2017
 
 [http://spyder-ide.blogspot.com/feeds/posts/default]
 name = Spyder IDE
+last_checked = Sun Aug 27 12:10:40 2017
 
 [http://westmarch.sjsoft.com/tag/python/feed/]
 name = St James Software Development
+last_checked = Sun Aug 27 12:10:42 2017
 
 [http://stackabuse.com/tag/python/rss]
 name = Stack Abuse
+last_checked = Sun Aug 27 12:10:43 2017
 
 [http://stacks.11craft.com/feeds/tag.python.atom.xml]
 name = Stacks
+last_checked = Sun Aug 27 12:10:43 2017
 
 [https://www.starzel.de/blog/starzel-de-python-blog/RSS]
 name = Starzel.de
+last_checked = Sun Aug 27 12:10:44 2017
 
 [http://blog.behnel.de/index.php?feed=rss2&cat=22]
 name = Stefan Behnel
+last_checked = Sun Aug 27 12:10:44 2017
 
 [http://blog.garage-coding.com/tag/python/feed.xml]
 name = Stefan Petrea
+last_checked = Sun Aug 27 12:10:45 2017
 
 [http://stefan.sofa-rockers.org/feeds/python]
 name = Stefan Scherfke
+last_checked = Sun Aug 27 12:10:47 2017
 
 [http://www.jodal.no/atom-python.xml]
 name = Stein Magnus Jodal
+last_checked = Sun Aug 27 12:10:49 2017
 
 [http://pythonconquerstheuniverse.wordpress.com/feed/atom/]
 name = Stephen Ferg
+last_checked = Sun Aug 27 12:10:49 2017
 
 [http://stevedower.id.au/blog/category/python/feed/]
 name = Steve Dower
+last_checked = Sun Aug 27 12:10:52 2017
 
 [http://holdenweb.blogspot.com/feeds/posts/default/-/python]
 name = Steve Holden
+last_checked = Sun Aug 27 12:10:52 2017
 
 [http://rh0dium.blogspot.com/feeds/posts/default/-/python]
 name = Steven Klass
+last_checked = Sun Aug 27 12:10:53 2017
 
 [http://blog.lost-theory.org/tags/python/feed.atom]
 name = Steven Kryskalla
+last_checked = Sun Aug 27 12:10:54 2017
 
 [http://www.devpicayune.com/category/python/feed]
 name = Steven Wilcox
+last_checked = Sun Aug 27 12:10:54 2017
 
-[http://stdout.be/tag/django/feed/]
-name = Stijn Debrouwere
+# [http://stdout.be/tag/django/feed/]
+# name = Stijn Debrouwere
+# notes = 404 Client Error: Not Found for url: http://debrouwere.org/tag/django/feed/
+# last_checked = Sun Aug 27 12:10:55 2017
 
 [https://storiesinmypocket.com/feed/python/]
 name = Stories in My Pocket
+last_checked = Sun Aug 27 12:10:57 2017
 
 [http://TuringFinance.com/category/python/feed/]
 name = Stuart Gordon Reid
+last_checked = Sun Aug 27 12:10:58 2017
 
 [http://wirtel.be/tags/python/index.xml]
 name = Stéphane Wirtel
+last_checked = Sun Aug 27 12:10:58 2017
 
 [http://sumith1896.github.io/feeds/feed.sympy.xml]
 name = Sumith - Blog about SymPy/Python
+last_checked = Sun Aug 27 12:10:59 2017
 
-[http://swaroopch.com/tag/python/feed/]
-name = Swaroop C H
+# [http://swaroopch.com/tag/python/feed/]
+# name = Swaroop C H
+# notes = 404 Client Error: Not Found for url: https://www.swaroopch.com/tag/python/feed/
+# last_checked = Sun Aug 27 12:11:00 2017
 
-[http://swiftstack.com/blog/python.xml]
-name = SwiftStack
+# [http://swiftstack.com/blog/python.xml]
+# name = SwiftStack
+# notes = 404 Client Error: Not Found for url: https://www.swiftstack.com/blog/python.xml
+# last_checked = Sun Aug 27 12:11:02 2017
 
 [http://ict.swisscom.ch/tag/python/feed]
 name = Swisscom ICT
+last_checked = Sun Aug 27 12:11:04 2017
 
 [http://www.defuze.org/archives/category/python/feed]
 name = Sylvain Hellegouarch
+last_checked = Sun Aug 27 12:11:05 2017
 
 [http://www.talkpythontome.com/episodes/rss]
 name = Talk Python to Me
+last_checked = Sun Aug 27 12:11:08 2017
 
 [http://blog.ziade.org/tag/python/feed]
 name = Tarek Ziade
+last_checked = Sun Aug 27 12:11:09 2017
 
 [http://blog.tedmiston.com/tag/python/rss]
 name = Taylor Edmiston
+last_checked = Sun Aug 27 12:11:10 2017
 
 [http://www.teachmepython.com/feed/]
 name = Teach Me Python
+last_checked = Sun Aug 27 12:11:11 2017
 
 [https://www.techiediaries.com/tag/django/index.xml]
 name = Techiediaries - Django
+last_checked = Sun Aug 27 12:11:13 2017
 
 [http://www.sauria.com/blog/category/programming-languages/python/feed/atom/]
 name = Ted Leung
+last_checked = Sun Aug 27 12:11:15 2017
 
-[http://philosophyofweb.com/category/python/feed/]
-name = Ted Nyman
+# [http://philosophyofweb.com/category/python/feed/]
+# name = Ted Nyman
+# notes = 404 Client Error: Not Found for url: http://philosophyofweb.com/category/python/feed/
+# last_checked = Sun Aug 27 12:11:16 2017
 
 [http://blog.teemu.im/tags/python/feed/]
 name = Teemu Harju
+last_checked = Sun Aug 27 12:11:16 2017
 
 [http://myownhat.blogspot.com/feeds/posts/default/-/python]
 name = Tennessee Leeuwenburg
+last_checked = Sun Aug 27 12:11:17 2017
 
 [http://terriko.dreamwidth.org/data/rss?tag=python]
 name = Terri Oda
+last_checked = Sun Aug 27 12:11:18 2017
 
 [http://blogs.fluidinfo.com/terry/category/python/feed/atom/]
 name = Terry Jones
+last_checked = Sun Aug 27 12:11:20 2017
 
 [http://swordstyle.com/blog2/?feed=rss2&cat=20]
 name = Terry Peppers
+last_checked = Sun Aug 27 12:11:21 2017
 
 [http://blog.aicookbook.com/category/python/feed/atom/]
 name = The Artificial Intelligence Cookbook
+last_checked = Sun Aug 27 12:11:22 2017
 
-[http://thechangelog.com/tagged/python/rss]
-name = The Changelog
+# [http://thechangelog.com/tagged/python/rss]
+# name = The Changelog
+# notes = 404 Client Error: Not Found for url: https://changelog.com/tagged/python/rss
+# last_checked = Sun Aug 27 12:11:23 2017
 
 [http://www.thedatascientist.de/category/python/feed/]
 name = The Data Scientist
+last_checked = Sun Aug 27 12:11:24 2017
 
 [http://blog.thedigitalcatonline.com/categories/python/atom.xml]
 name = The Digital Cat
+last_checked = Sun Aug 27 12:11:26 2017
 
 [http://blog.dowski.com/category/python/feed]
 name = The Occasional Occurrence
+last_checked = Sun Aug 27 12:11:26 2017
 
 [http://blog.parcon.opengroove.org/feeds/posts/default]
 name = The Parcon Blog
+last_checked = Sun Aug 27 12:11:26 2017
 
 [http://pythonpapers.blogspot.com/atom.xml]
 name = The Python Papers
+last_checked = Sun Aug 27 12:11:27 2017
 
 [https://threeofwands.com/tag/python/rss/]
 name = The Three of Wands
+last_checked = Sun Aug 27 12:11:27 2017
 
 [http://avelino.xxx/python-en/feed]
 name = Thiago Avelino
+last_checked = Sun Aug 27 12:11:28 2017
 
 [http://www.tibonihoo.net/blog/en/tag/python/feed/]
 name = Thibauld Nion
+last_checked = Sun Aug 27 12:11:31 2017
 
-[http://ballingt.com/feed.python.xml]
-name = "Thomas Ballinger's Blog"
+# [http://ballingt.com/feed.python.xml]
+# name = "Thomas Ballinger's Blog"
+# notes = 404 Client Error: Not Found for url: http://ballingt.com/feed.python.xml
+# last_checked = Sun Aug 27 12:11:31 2017
 
 [http://feeds.wordaligned.org/wordaligned/python]
 name = Thomas Guest
+last_checked = Sun Aug 27 12:11:32 2017
 
 [http://thomas.apestaart.org/log/?feed=rss2&cat=22]
 name = Thomas Vander Stichele
+last_checked = Sun Aug 27 12:11:33 2017
 
 [http://www.tech-foo.net/feeds/tag-python.atom.xml]
 name = Thomi Richards
+last_checked = Sun Aug 27 12:11:35 2017
 
 [https://www.tibobeijen.nl/tags/python/index.xml]
 name = Tibo Beijen
+last_checked = Sun Aug 27 12:11:35 2017
 
 [http://timgilbert.wordpress.com/category/python/feed/atom/]
 name = Tim Gilbert
+last_checked = Sun Aug 27 12:11:35 2017
 
 [http://ramblings.timgolden.me.uk/category/tech/python/feed/]
 name = Tim Golden
+last_checked = Sun Aug 27 12:11:36 2017
 
 [http://feeds.feedburner.com/duffyd]
 name = Tim Knapp
+last_checked = Sun Aug 27 12:11:38 2017
 
 [http://apipes.blogspot.com/feeds/posts/default/-/python]
 name = Tim Lesher
+last_checked = Sun Aug 27 12:11:38 2017
 
 [http://dev.timparkin.co.uk/feeds/posts/default?alt=rss]
 name = Tim Parkin
+last_checked = Sun Aug 27 12:11:39 2017
 
 [http://www.shisaa.jp/categories/python.xml]
 name = Tim van der Linden
+last_checked = Sun Aug 27 12:11:40 2017
 
-[http://ivory.idyll.org/blog/tags/python?flav=atom]
-name = Titus Brown
+# [http://ivory.idyll.org/blog/tags/python?flav=atom]
+# name = Titus Brown
+# notes = 404 Client Error: Not Found for url: http://ivory.idyll.org/blog/tags/python?flav=atom
+# last_checked = Sun Aug 27 12:11:41 2017
 
 [http://feeds.feedburner.com/thobe/wardrobe]
 name = Tobias Ivarsson
+last_checked = Sun Aug 27 12:11:41 2017
 
 [http://thewebhaswon.wordpress.com/category/python/atom]
 name = Tom Christie
+last_checked = Sun Aug 27 12:11:41 2017
 
 [http://www.sys-exit.blogspot.com/feeds/posts/default/-/python]
 name = Tomasz Ducin
+last_checked = Sun Aug 27 12:11:42 2017
 
 [http://pragmaticpython.com/feed/?tag=python]
 name = Tomasz Früboes
+last_checked = Sun Aug 27 12:11:42 2017
 
 [http://www.tomaz.me/tags/python.xml]
 name = Tomaž Muraus
+last_checked = Sun Aug 27 12:11:43 2017
 
 [http://tomerfiliba.com/blog/python-atom.xml]
 name = Tomer Filiba
+last_checked = Sun Aug 27 12:11:43 2017
 
 [http://tonybreyal.wordpress.com/category/python/feed/atom/]
 name = Tony Breyal
+last_checked = Sun Aug 27 12:11:44 2017
 
 [http://better-inter.net/rss/python/]
 name = Torsten Engelbrecht
+last_checked = Sun Aug 27 12:11:44 2017
 
 [http://anonbadger.wordpress.com/tag/python/feed/atom/]
 name = Toshio Kuratomi
+last_checked = Sun Aug 27 12:11:45 2017
 
 [http://technicaldiscovery.blogspot.com/feeds/posts/default/-/python]
 name = Travis Oliphant
+last_checked = Sun Aug 27 12:11:45 2017
 
 [http://treyhunner.com/python.xml]
 name = Trey Hunner
+last_checked = Sun Aug 27 12:11:45 2017
 
 [http://blog.melhase.net/xml/rss20/feed.xml]
 name = Troy Melhase
+last_checked = Sun Aug 27 12:11:46 2017
 
 [http://www.tryton.org/rss.xml]
 name = Tryton News
+last_checked = Sun Aug 27 12:11:46 2017
 
 [http://www.turnkeylinux.org/taxonomy/term/103/0/feed]
 name = Turnkey Linux
+last_checked = Sun Aug 27 12:11:47 2017
 
 [http://feeds.feedburner.com/TwistedMatrixLaboratories]
 name = Twisted Matrix Labs
+last_checked = Sun Aug 27 12:11:47 2017
 
-[http://copia.posterous.com/rss.xml?tag=python]
-name = Uche Ogbuji
+# [http://copia.posterous.com/rss.xml?tag=python]
+# name = Uche Ogbuji
+# notes = 503 Server Error: Service Unavailable for url: http://copia.posterous.com/rss.xml?tag=python
+# last_checked = Sun Aug 27 12:11:53 2017
 
 [http://united-coders.com/taxonomy/term/22/0/feed]
 name = United Coders
+last_checked = Sun Aug 27 12:11:54 2017
 
 [http://vsbabu.org/mt/index.rdf]
 name = V.S. Babu
+last_checked = Sun Aug 27 12:11:54 2017
 
 [http://prayogshala.wordpress.com/category/scripting/python/feed/atom/]
 name = Varun Nischal
+last_checked = Sun Aug 27 12:11:55 2017
 
 [http://jugad2.blogspot.co.uk/feeds/posts/default/-/python]
 name = Vasudev Ram
+last_checked = Sun Aug 27 12:11:55 2017
 
 [http://pymolurus.blogspot.com/feeds/posts/default]
 name = Vinay Sajip
+last_checked = Sun Aug 27 12:11:55 2017
 
 [http://plumberjack.blogspot.com/feeds/posts/default]
 name = Vinay Sajip (Logging)
+last_checked = Sun Aug 27 12:11:56 2017
 
 [http://www.hardcoded.net/articles/rss_python.xml]
 name = Virgil Dupras
+last_checked = Sun Aug 27 12:11:57 2017
 
-[http://www.jrandolph.com/blog/category/python/feed/atom/]
-name = Viva La Chipperfish
+# [http://www.jrandolph.com/blog/category/python/feed/atom/]
+# name = Viva La Chipperfish
+# notes = 404 Client Error: Not Found for url: http://www.jrandolph.com/blog/category/python/feed/atom/
+# last_checked = Sun Aug 27 12:11:57 2017
 
 [https://nvbn.github.io/feed.python.xml]
 name = Vladimir Iakolev
+last_checked = Sun Aug 27 12:11:57 2017
 
 [http://www.vperic.blogspot.com/feeds/posts/default/-/Twisted]
 name = Vladimir Perić
+last_checked = Sun Aug 27 12:11:58 2017
 
 [http://www.wallix.org/tag/python/feed/atom/]
 name = Wallix
+last_checked = Sun Aug 27 12:11:59 2017
 
 [http://www.djangotimes.com/feeds/posts/all/]
 name = Washington Times OpenSource
+last_checked = Sun Aug 27 12:11:59 2017
 
 [http://pieceofpy.com/category/python/feed/atom/index.xml]
 name = Wayne Witzel
+last_checked = Sun Aug 27 12:12:00 2017
 
 [http://www.weeklypython.chat/feed/]
 name = Weekly Python Chat
+last_checked = Sun Aug 27 12:12:02 2017
 
 [http://python-weekly.blogspot.com/feeds/posts/default?alt=rss]
 name = Weekly Python StackOverflow Report
+last_checked = Sun Aug 27 12:12:02 2017
 
 [http://1stvamp.org/tag/python/atom/]
 name = Wes Mason
+last_checked = Sun Aug 27 12:12:03 2017
 
 [http://wescpy.blogspot.com/feeds/posts/default/-/python]
 name = Wesley Chun
+last_checked = Sun Aug 27 12:12:03 2017
 
 [http://www.wiggy.net/atom.python.xml]
 name = Wichert Akkerman
+last_checked = Sun Aug 27 12:12:03 2017
 
 [http://bluesock.org/~willkg/blog/tag/python.xml]
 name = Will Kahn-Greene
+last_checked = Sun Aug 27 12:12:04 2017
 
 [http://www.willmcgugan.com/blog/tech/feeds/posts/]
 name = Will McGugan
+last_checked = Sun Aug 27 12:12:05 2017
 
 [http://willpython.blogspot.com/feeds/posts/default]
 name = Will Pierce
+last_checked = Sun Aug 27 12:12:06 2017
 
 [http://blog.minchin.ca/feeds/label.python.atom.xml]
 name = William Minchin
+last_checked = Sun Aug 27 12:12:06 2017
 
 [http://foolish-assertions.blogspot.com/feeds/posts/default/-/python]
 name = William Reade
+last_checked = Sun Aug 27 12:12:06 2017
 
 [http://dietbuddha.blogspot.com/feeds/posts/default/-/python]
 name = William Thompson
+last_checked = Sun Aug 27 12:12:07 2017
 
 [http://william-os4y.livejournal.com/data/atom]
 name = "William's Journal"
+last_checked = Sun Aug 27 12:12:07 2017
 
 [http://wingware.com/blog/rss&noheader=1]
 name = Wingware Blog
+last_checked = Sun Aug 27 12:12:08 2017
 
 [http://wingware.com/news/rss&noheader=1]
 name = Wingware News
+last_checked = Sun Aug 27 12:12:08 2017
 
-[http://wolfram.kriesing.de/blog/index.php/category/programming/python/feed]
-name = Wolfram Kriesing
+# [http://wolfram.kriesing.de/blog/index.php/category/programming/python/feed]
+# name = Wolfram Kriesing
+# notes = 404 Client Error: Not Found for url: http://wolfram.kriesing.de/blog/index.php/category/programming/python/feed
+# last_checked = Sun Aug 27 12:12:09 2017
 
 [http://blog.wraithan.net/tag/python/feed/]
 name = Wraithan
+last_checked = Sun Aug 27 12:12:09 2017
 
 [http://blog.wyattbaldwin.com/feed/planet-python/atom.xml]
 name = Wyatt Baldwin
+last_checked = Sun Aug 27 12:12:10 2017
 
-[http://blog.madpython.com/tag/python/feed/atom/]
-name = Xavier Spriet
+# [http://blog.madpython.com/tag/python/feed/atom/]
+# name = Xavier Spriet
+# notes = 404 Client Error: Not Found for url: http://blog.madpython.com/tag/python/feed/atom/
+# last_checked = Sun Aug 27 12:12:10 2017
 
 [http://www.yaco.es/blog/en/tag/python-en/feed/]
 name = Yaco
+last_checked = Sun Aug 27 12:12:13 2017
 
 [http://tech.blog.aknin.name/tag/python/feed/atom/]
 name = Yaniv Aknin
+last_checked = Sun Aug 27 12:12:14 2017
 
 [http://www.ylarrivee.com/tag/python/feed/]
 name = Yann Larrivée
+last_checked = Sun Aug 27 12:12:15 2017
 
-[http://ygingras.net/b/feed/python]
-name = Yannick Gingras
+# [http://ygingras.net/b/feed/python]
+# name = Yannick Gingras
+# notes = 404 Client Error: Not Found for url: http://ygingras.net/b/feed/python
+# last_checked = Sun Aug 27 12:12:15 2017
 
 [http://freepythontips.wordpress.com/feed/atom]
 name = Yasoob Khalid
+last_checked = Sun Aug 27 12:12:17 2017
 
-[https://yoongkang.com/feeds/all.atom.xml]
-name = Yoong Kang Lim
+# [https://yoongkang.com/feeds/all.atom.xml]
+# name = Yoong Kang Lim
+# notes = 404 Client Error: Not Found for url: https://yoongkang.com/feeds/all.atom.xml
+# last_checked = Sun Aug 27 12:12:18 2017
 
 [http://uberpython.wordpress.com/tag/python/feed/atom/]
 name = Yuval Greenfield
+last_checked = Sun Aug 27 12:12:20 2017
 
-[http://blog.zacharyvoase.com/tagged/python/rss]
-name = Zachary Voase
+# [http://blog.zacharyvoase.com/tagged/python/rss]
+# name = Zachary Voase
+# notes = 404 Client Error: Not Found for url: http://zacharyvoase.com/tagged/python/rss/
+# last_checked = Sun Aug 27 12:12:20 2017
 
 [http://za.github.io/feed.python.xml]
 name = Zaki Akhmad
+last_checked = Sun Aug 27 12:12:20 2017
 
 [http://blogfeed.zato.io/blog/categories/planet-python.xml]
 name = Zato Blog
+last_checked = Sun Aug 27 12:12:20 2017
 
 [https://medium.com/feed/@ZeroDB_]
 name = ZeroDB
+last_checked = Sun Aug 27 12:12:21 2017
 
-[http://commandline.org.uk/feeds/full/python/]
-name = Zeth
+# [http://commandline.org.uk/feeds/full/python/]
+# name = Zeth
+# notes = 404 Client Error: Not Found for url: https://zeth.net/feeds/full/python/
+# last_checked = Sun Aug 27 12:12:22 2017
 
 [http://blog.bottlepy.org/feeds/all.atom.xml]
 name = bottlepy-dev
+last_checked = Sun Aug 27 12:12:22 2017
 
 [http://feeds.feedburner.com/codeboje_python]
 name = codeboje
+last_checked = Sun Aug 27 12:12:23 2017
 
 [http://www.egenix.com/company/news/rss2]
 name = eGenix.com
+last_checked = Sun Aug 27 12:12:23 2017
 
 [http://hypothesis.works/articles/python/feed/]
 name = hypothesis.works articles
+last_checked = Sun Aug 27 12:12:24 2017
 
 [http://scummos.blogspot.com/feeds/posts/default/-/kdev-python]
 name = kdev-python
+last_checked = Sun Aug 27 12:12:24 2017
 
 [http://nl-project.blogspot.com/feeds/posts/default/-/python]
 name = nl-project
+last_checked = Sun Aug 27 12:12:25 2017
 
 [http://pgcli.com/feeds/tag.python.atom.xml]
 name = pgcli
+last_checked = Sun Aug 27 12:12:26 2017
 
 [http://www.pythonwise.blogspot.com/feeds/posts/default/-/python]
 name = pythonwise
+last_checked = Sun Aug 27 12:12:26 2017
 
 [http://blog.qutebrowser.org/feeds/tag-pyplanet.rss.xml]
 name = qutebrowser development blog
+last_checked = Sun Aug 27 12:12:26 2017
 
 [https://medium.com/feed/@tryexceptpass]
 name = tryexceptpass
+last_checked = Sun Aug 27 12:12:28 2017
 
 [http://radar.wiredobjects.eu/category/python/feed/]
 name = wiredobjects
+last_checked = Sun Aug 27 12:12:29 2017
 
-[http://zombofant.net/blog/tags/python?feed=atom]
-name = zombofant.net
+# [http://zombofant.net/blog/tags/python?feed=atom]
+# name = zombofant.net
+# notes = HTTPConnectionPool(host='zombofant.net', port=80): Max retries exceeded with url: /blog/tags/python?feed=atom (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x03A98370>: Failed to establish a new connection: [Errno 11001] getaddrinfo failed',))
+# last_checked = Sun Aug 27 12:12:29 2017
 
 [http://wokslog.wordpress.com/tag/python/feed/atom/]
 name = Éric Araujo
+last_checked = Sun Aug 27 12:12:30 2017
 
 [http://lukasz.langa.pl/feed/tag/python/rss-en.xml]
 name = Łukasz Langa
+last_checked = Sun Aug 27 12:12:30 2017
 
 [http://pyarab.blogspot.se/atom.xml]
 name = بايثون العربي
+last_checked = Sun Aug 27 12:12:33 2017
 

--- a/config/strip-404.py
+++ b/config/strip-404.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+import sys
+import ConfigParser
+import time
+import urllib2
+#
+# Using requests because it handles things
+# HTTPS better than urllib2 (at least on 2.7)
+#
+import requests
+
+if len(sys.argv) > 1:
+    filename = sys.argv[1]
+else:
+    filename = 'config.ini'
+    
+oconfig = ConfigParser.RawConfigParser()
+oconfig.read(filename)
+
+def write_section(f, section_name, prefix="", notes=""):
+    f.write("%s[%s]\n" % (prefix, section_name))
+    for key, value in oconfig.items(section_name):
+        if "'" in key: key = '"%s"' % key
+        f.write("%s%s = %s\n" % (prefix, key, str(value).replace('\n', '\n\t')))
+    if notes:
+        f.write("%snotes = %s\n" % (prefix, notes))
+    f.write("%slast_checked = %s\n" % (prefix, time.asctime()))
+    f.write("\n")
+
+#
+# This is basically a clone of sort-ini which leaves the sort
+# order the same but checks whether a feed is giving an error
+# and comments it out
+#
+with open(filename, "wb") as f:
+    for section_name in oconfig.sections():
+        print section_name
+        if section_name == 'Planet':
+            write_section(f, section_name)
+        else:
+            try:
+                requests.get(section_name).raise_for_status()
+            except requests.RequestException as exc:
+                print "Failed because:", exc.message
+                write_section(f, section_name, "# ", exc.message)
+            except Exception as exc:
+                print "Problem:", exc
+                write_section(f, section_name, "# ")
+            else:
+                write_section(f, section_name)


### PR DESCRIPTION
This is step#1 in addressing the problems we've been having with some failing feeds. I've written something ad hoc in config\script-404.py which will comment out of the config.ini any feeds which give some kind of error (404, DNS failure, whatever...). It also tags each feed with the timestamp of the check.

The idea is to take out of the picture those feeds which aren't going to give us anything useful.

Those which are left have, at least, a valid endpoint and might have a valid feed. We can then start to look more at errors in the feed parse or whatever. Please have a look and see if there any obvious problems with the approach.

Clearly, we can very easily revert any changes to the config file if there is some difficulty.