### PR TITLE
Update PyBites RSS feed

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -1752,7 +1752,7 @@ name = Przemysław Kołodziejczyk
 [http://blog.pyamf.org/feed]
 name = PyAMF Blog
 
-[https://pybit.es/feeds/all.rss.xml]
+[https://pybit.es/feeds/all.atom.xml]
 name = PyBites
 
 [http://blog.pycarolinas.org/rss/]


### PR DESCRIPTION
Still not seeing PyBites entries, trying again with atom feed (generated with latest Pelican 3.7.1)

# EDIT FEED
------------------------------------------------------------------------------
Hi, I want to change my current feed url from https://pybit.es/feeds/all.rss.xml to https://pybit.es/feeds/all.atom.xml

## I checked the following required validations:  (mark all 4 with [x])

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=MY_FEED_URL and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)

Thanks in advance for changing my feed on Python Planet! :+1: