### PR TITLE
Update URL feed for eshlox.net

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -1749,7 +1749,7 @@ name = Programiz
 [https://programmingideaswithjake.wordpress.com/category/python/feed/rdf/]
 name = Programming Ideas With Jake
 
-[https://eshlox.net/tag/python/rss/index.xml]
+[https://eshlox.net/tags/python/index.xml]
 name = Przemysław Kołodziejczyk
 
 [http://blog.pyamf.org/feed]


### PR DESCRIPTION
Hi, I want to change my current feed url from https://eshlox.net/tag/python/rss/index.xml to https://eshlox.net/tags/python/index.xml

## I checked the following required validations:

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=https://eshlox.net/tags/python/index.xml and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)

Thanks in advance for changing my feed on Python Planet! :+1: