### PR TITLE
Updating url for pythondebugging.com

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -1875,7 +1875,7 @@ name = Python(x,y) News
 [http://pythonclub.com.br/feeds/all.atom.xml]
 name = PythonClub - A Brazilian collaborative blog about Python
 
-[https://pythondebugging.com/category/python/feed.xml]
+[http://pythondebugging.com/category/python/feed.xml]
 name = PythonDebugging.com
 
 [http://www.pythonthreads.com/index2.php?option=com_rss&feed=RSS2.0&no_html=1]


### PR DESCRIPTION
# EDIT FEED
------------------------------------------------------------------------------
Hi, I want to change my current feed url from CURRENT_URL_HERE to NEW_URL_HERE

## I checked the following required validations:  (mark all 4 with [x])

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=http%3A%2F%2Fpythondebugging.com%2Fcategory%2Fpython%2Ffeed.xml and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)

Thanks in advance for changing my feed on Python Planet! :+1:
