### PR TITLE
Add Read the Docs Python-specific feed

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -1947,6 +1947,9 @@ name = Raymond Li
 [http://reachtim.com/feeds/python.atom.xml]
 name = Reach Tim
 
+[http://blog.readthedocs.com/archive/tag/python/atom.xml]
+name = Read the Docs
+
 [https://realpython.com/atom.xml]
 name = Real Python
 


### PR DESCRIPTION
# ADD FEED
-------------------------------------------------------------------------------

Hi, I want to add my feed to the Python Planet.

## I checked the following required validations: (mark all 4 with [x])

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=http://blog.readthedocs.com/archive/tag/python/atom.xml and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)

Thanks in advance for adding my feed to the PythonPlanet! :+1:


**Note:** I ran the `sort-ini.py` but it moved some other things so I backed those changes out. This is the position where this feed should go through.
