### PR TITLE
Change Data School RSS URL from http to https

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -522,7 +522,7 @@ name = Dariusz Suchojad
 [http://datacommunitydc.org/blog/tag/python/feed/]
 name = Data Community DC
 
-[http://www.dataschool.io/tag/python/rss/]
+[https://www.dataschool.io/tag/python/rss/]
 name = Data School
 
 [https://www.datacamp.com/community/blog/python-feed.rss]


### PR DESCRIPTION
# EDIT FEED
------------------------------------------------------------------------------
Hi, I want to change my current feed url from http://www.dataschool.io/tag/python/rss/ to https://www.dataschool.io/tag/python/rss/

## I checked the following required validations:  (mark all 4 with [x])

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=MY_FEED_URL and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)

I recently updated my blog from http and https, and my latest post did not show up on the Planet Python site. I thought perhaps the issue was due to the RSS feed still being listed as http.