### PR TITLE
Update link to current Spyder blog feed

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -2151,7 +2151,7 @@ name = "Speno's Pythonic Avocado"
 [http://spikeekips.tumblr.com/tagged/python/rss]
 name = Spike ekipS
 
-[http://spyder-ide.blogspot.com/feeds/posts/default]
+[https://www.spyder-ide.org/blog/feed.xml]
 name = Spyder IDE
 
 [http://westmarch.sjsoft.com/tag/python/feed/]


### PR DESCRIPTION
# EDIT FEED
------------------------------------------------------------------------------
Hi, I want to change my current feed url from [http://spyder-ide.blogspot.com/feeds/posts/default] to [https://www.spyder-ide.org/blog/feed.xml]

## I checked the following required validations:  (mark all 4 with [x])

1. [x] My feed is valid, I checked using [https://validator.w3.org/feed/check.cgi?url=https://www.spyder-ide.org/blog/feed.xml] and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)

Thanks in advance for changing my feed on Python Planet! :+1:

The present feed is long out of date; there hasn't been a post to that blog in years. The replacement feed is in HTTPS and Atom 1.0 to our new official blog on our dedicated site, and also focuses more specifically on just the Spyder IDE, a popular (~100,000s active users) Python-exclusive IDE for data science written in 100% pure Python (and its plugins and related project, also all Python). As the official blog of the Spyder project, posts only related to news, updates, and how-tos for Python, the PyData stack and Spyder specific, rather than personal musings, rants, or general ramblings.

A part of the bigger link update project coordinated in spyder-ide/spyder-docs#39

Thanks!
