### PR TITLE
Add PyCoder's Weekly feed

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -2256,3 +2256,6 @@ name = بايثون العربي
 
 [https://zerowithdot.com/feed.xml]
 name = Zero-with-Dot (Oleg Żero)
+
+[https://pycoders.com/feed/planetpython]
+name = PyCoder’s Weekly


### PR DESCRIPTION
Hi, I want to add our feed to the Python Planet.

## I checked the following required validations: (mark all 4 with [x])

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=MY_FEED_URL and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)

Thanks in advance for adding my feed to the PythonPlanet! :+1: