### PR TITLE
Adding DaPythonista feed

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -15,9 +15,6 @@ link = http://planetpython.org/
 template_files = config/index.html.tmpl config/rss20.xml.tmpl config/rss10.xml.tmpl config/opml.xml.tmpl config/foafroll.xml.tmpl config/summary.html.tmpl config/titles_only.html.tmpl
 cache_directory = /srv/cache
 
-[http://codingdirectional.info/category/python/feed/]
-name = codingdirectional
-
 [http://dev.2degreesnetwork.com/feeds/posts/default/-/python]
 name = 2degrees
 
@@ -377,6 +374,9 @@ name = Curtis Miller
 
 [http://dspillustrations.com/static/dspillustrations.rss.xml]
 name = DSPIllustrations.com
+
+[http://dapythonista.com/?feed=rdf]
+name = DaPythonista
 
 [http://dailytechvideo.com/category/python/feed/]
 name = Daily Tech Video (Python)
@@ -2036,6 +2036,9 @@ name = bottlepy-dev
 
 [http://feeds.feedburner.com/codeboje_python]
 name = codeboje
+
+[http://codingdirectional.info/category/python/feed/]
+name = codingdirectional
 
 [http://www.egenix.com/company/news/rss2]
 name = eGenix.com


### PR DESCRIPTION
Hi, I want to add my feed to the Python Planet.

## I checked the following required validations: (mark all 4 with [x])

1. [ x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=MY_FEED_URL and it is valid!
2. [ x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. x[ ] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x ] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)

Thanks in advance for adding my feed to the PythonPlanet! :+1:
