### PR TITLE
Fix broken feed URL.

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -1089,7 +1089,7 @@ name = Marko Samastur
 [http://blog.startifact.com/categories/planetpython.xml]
 name = Martijn Faassen
 
-[https://www.mfitzp.com.net/feeds/python.tag.atom.xml]
+[https://www.mfitzp.com/feeds/python.tag.atom.xml]
 name = Martin Fitzpatrick
 
 [http://feeds.feedburner.com/zopatista/python]


### PR DESCRIPTION
Broken feed URL (.com.net -> .com), screwed it up on the last PR. Apologies for the faff.

# EDIT FEED
------------------------------------------------------------------------------
Hi, I want to change my current feed url from CURRENT_URL_HERE to NEW_URL_HERE

## I checked the following required validations:  (mark all 4 with [x])

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=MY_FEED_URL and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)

Thanks in advance for changing my feed on Python Planet! :+1:

