### PR TITLE
Update config.ini

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -15,6 +15,9 @@ link = http://planetpython.org/
 template_files = config/index.html.tmpl config/rss20.xml.tmpl config/rss10.xml.tmpl config/opml.xml.tmpl config/foafroll.xml.tmpl config/summary.html.tmpl config/titles_only.html.tmpl
 cache_directory = /srv/cache
 
+[http://leftmouseclickin.com/category/python/feed/]
+name = leftmouseclickin
+
 [https://medium.com/feed/python4you]
 name = Artem Rys
 


### PR DESCRIPTION
# EDIT FEED
------------------------------------------------------------------------------
Hi, I want to change my current feed url from http://leftmouseclickin.com/python/feed/ to http://leftmouseclickin.com/category/python/feed/

## I checked the following required validations:  (mark all 4 with [x])

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=http://leftmouseclickin.com/category/python/feed/ and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)

Thanks in advance for changing my feed on Python Planet! :+1: