### PR TITLE
Added Django central to the feed

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -2106,3 +2106,5 @@ name = Łukasz Langa
 [http://pyarab.blogspot.se/atom.xml]
 name = بايثون العربي
 
+[https://djangocentral.com/feed/]
+name = Abhijeet Pal


### PR DESCRIPTION
Hi, I want to add my feed to the Python Planet.


1. [https://djangocentral.com/feed/ ] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=MY_FEED_URL and it is valid!
2. [https://djangocentral.com/feed/ ] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [https://djangocentral.com/feed/ ] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [https://djangocentral.com/feed/ ] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)

Thanks in advance for adding my feed to the PythonPlanet! :+1:

