### PR TITLE
Update config.ini

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -1020,6 +1020,9 @@ name = Lion Kimbro
 [http://lionel.textmalaysia.com/category/programming/python/feed]
 name = Lionel Tan
 
+[https://www.listendata.com/feeds/posts/default/-/Python]
+name = ListenData
+
 [http://feeds.feedburner.com/logilaborg_en]
 name = Logilab
 


### PR DESCRIPTION
# ADD FEED
-------------------------------------------------------------------------------

Hi, I want to add my feed to the Python Planet.

My Python specific feed URL : https://www.listendata.com/feeds/posts/default/-/Python

## I checked the following required validations: (mark all 5 with [x])

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fwww.listendata.com%2Ffeeds%2Fposts%2Fdefault%2F-%2FPython and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)
5. [x] My feed contains only content in English language.

Thanks in advance for adding my feed to the PythonPlanet! :+1:

