### PR TITLE
Remove Neckbeard Republic

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -1254,9 +1254,6 @@ name = Nathan Lemoine
 [https://blog.datasciencedojo.com/tag/python-programming/rss/]
 name = Nathan Piccini Data Science Dojo Blog
 
-[https://www.neckbeardrepublic.com/rss/]
-name = Neckbeard Republic
-
 [http://nedbatchelder.com/blog/planetpython.xml]
 name = Ned Batchelder
 


### PR DESCRIPTION
It now redirects to Real Python (paid) courses: https://realpython.com/courses/atom.xml

Or is it better to just change the name? Is it ok to advertise paid courses in the Planet?

