### PR TITLE
Change names of Wingware feeds

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -2062,10 +2062,10 @@ name = William Thompson
 name = "William's Journal"
 
 [http://wingware.com/blog/rss&noheader=1]
-name = Wingware Blog
+name = Wing Tips
 
 [http://wingware.com/news/rss&noheader=1]
-name = Wingware News
+name = Wingware
 
 [http://blog.wraithan.net/tag/python/feed/]
 name = Wraithan


### PR DESCRIPTION
Hi, I want to change just the name of my current feeds without changing the URLs.

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=MY_FEED_URL and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)
5. [x] My feed contains only content in English language.

Thanks!

Stephan Deibel
sdeibel@wingware.com
