### PR TITLE
GitHub Action to lint Python 2 code

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,16 @@
+# GitHub Action to automate the identification of common misspellings in text files
+ #   and Python syntax errors and undefined names.
+ # https://github.com/codespell-project/codespell and https://gitlab.com/pycqa/flake8
+ name: lint_python
+ on: [push, pull_request]
+ jobs:
+   lint_python:
+     runs-on: ubuntu-latest
+     steps:
+       - uses: actions/checkout@v2
+       - uses: actions/setup-python@v1
+         with:
+           python-version: 2.7
+       - run: pip install codespell flake8
+       - run: codespell -L squirl,uptodate,UPTODATE --skip=./.*,./config/config.ini
+       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -12,5 +12,5 @@
          with:
            python-version: 2.7
        - run: pip install codespell flake8
-       - run: codespell -L squirl,uptodate,UPTODATE --skip=./.*,./config/config.ini
+       - run: codespell -L nto,squirl,uptodate,UPTODATE --skip=./.*,./config/config.ini
        - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/code/planet/__init__.py
+++ b/code/planet/__init__.py
@@ -44,7 +44,7 @@ except:
 # Version information (for generator headers)
 VERSION = ("Planet/%s +http://www.planetplanet.org" % __version__)
 
-# Default User-Agent header to send when retreiving feeds
+# Default User-Agent header to send when retrieving feeds
 USER_AGENT = VERSION + " " + feedparser.USER_AGENT
 
 # Default cache directory

--- a/code/planet/cache.py
+++ b/code/planet/cache.py
@@ -7,7 +7,7 @@ we parsed, this is so we don't lose information when a particular feed
 goes away or is too short to hold enough items.
 
 This module provides the code to handle this cache transparently enough
-that the rest of the code can take the persistance for granted.
+that the rest of the code can take the persistence for granted.
 """
 
 import os

--- a/code/planet/compat_logging/config.py
+++ b/code/planet/compat_logging/config.py
@@ -240,7 +240,7 @@ def listen(port=DEFAULT_LOGGING_CONFIG_PORT):
                     fileConfig(file)
                     os.remove(file)
             except socket.error, e:
-                if type(e.args) != types.TupleType:
+                if not isinstance(e.args, tuple):
                     raise
                 else:
                     errcode = e.args[0]

--- a/code/planet/feedparser.py
+++ b/code/planet/feedparser.py
@@ -1840,7 +1840,7 @@ def _open_resource(url_file_stream_or_string, etag, modified, agent, referrer, h
     User-Agent request header.
 
     If the referrer argument is supplied, it will be used as the value of a
-    Referer[sic] request header.
+    Referrer request header.
 
     If handlers is supplied, it is a list of handlers used to build a
     urllib2 opener.

--- a/code/planet/htmltmpl.py
+++ b/code/planet/htmltmpl.py
@@ -439,7 +439,7 @@ class TemplateProcessor:
             should be automatically looked up in enclosing scopes.
 
             Automatic global lookup is disabled by default. Global lookup
-            can be overriden on a per-variable basis by the
+            can be overridden on a per-variable basis by the
             <strong>GLOBAL</strong> parameter of a <strong>TMPL_VAR</strong>
             statement.
 
@@ -681,7 +681,7 @@ class TemplateProcessor:
                         output_control.pop()
                         self.DEB("LOOP: END")
                     else:
-                        # Jump to the beggining of this loop block 
+                        # Jump to the beginning of this loop block 
                         # to process next pass of the loop.
                         i = loop_start[-1]
                         self.DEB("LOOP: NEXT PASS")
@@ -934,7 +934,7 @@ class TemplateCompiler:
         class. The compiled form is used as input for the TemplateProcessor
         which uses it to actually process the template.
 
-        This class should be used direcly only when you need to compile
+        This class should be used directly only when you need to compile
         a template from a string. If your template is in a file, then you
         should use the <em>TemplateManager</em> class which provides
         a higher level interface to this class and also can save the
@@ -1234,7 +1234,7 @@ class TemplateCompiler:
     
     def strip_brackets(self, statement):
         """ Strip HTML brackets (with optional HTML comments) from the
-            beggining and from the end of a statement.
+            beginning and from the end of a statement.
             @hidden
         """
         if statement.startswith("<!-- TMPL_") or \
@@ -1254,7 +1254,7 @@ class TemplateCompiler:
 
     def find_name(self, params):
         """ Extract identifier from a statement. The identifier can be
-            specified both implicitely or explicitely as a 'NAME' parameter.
+            specified both implicitly or explicitly as a 'NAME' parameter.
             @hidden
         """
         if len(params) > 0 and '=' not in params[0]:

--- a/code/planet/sanitize.py
+++ b/code/planet/sanitize.py
@@ -19,7 +19,7 @@ TIDY_MARKUP = 0
 # if TIDY_MARKUP = 1
 PREFERRED_TIDY_INTERFACES = ["uTidy", "mxTidy"]
 
-import sgmllib, re
+import sgmllib, sys, re
 
 # chardet library auto-detects character encodings
 # Download from http://chardet.feedparser.org/

--- a/config/sort-ini.py
+++ b/config/sort-ini.py
@@ -18,7 +18,7 @@ fd = open(filename, 'wb')
 def write():
     # Copy of write() code that sorts output by section
     if oconfig._defaults:
-        fd.write("[%s]\n" % DEFAULTSECT)
+        fd.write("[%s]\n" % ConfigParser.DEFAULTSECT)
         for (key, value) in oconfig._defaults.items():
             fd.write("%s = %s\n" % (key, str(value).replace('\n', '\n\t')))
         fd.write("\n")


### PR DESCRIPTION
Like #390 but for legacy Python.

Fix typos found by codespell and undefined names found by flake8:

% __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```python
./config/sort-ini.py:21:29: F821 undefined name 'DEFAULTSECT'
        fd.write("[%s]\n" % DEFAULTSECT)
                            ^
./code/planet/sanitize.py:47:20: F821 undefined name 'sys'
        if _debug: sys.stderr.write('entering BaseHTMLProcessor, encoding=%s\n' % self.encoding)
                   ^
./code/planet/sanitize.py:79:20: F821 undefined name 'sys'
        if _debug: sys.stderr.write('_BaseHTMLProcessor, unknown_starttag, tag=%s\n' % tag)
                   ^
./code/planet/sanitize.py:112:20: F821 undefined name 'sys'
        if _debug: sys.stderr.write('_BaseHTMLProcessor, handle_text, text=%s\n' % text)
                   ^
./code/planet/compat_logging/config.py:243:36: F821 undefined name 'types'
                if type(e.args) != types.TupleType:
                                   ^
5     F821 undefined name 'types'
5
```