### PR TITLE
Edit Daniel and Audrey's feed locations

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -159,7 +159,7 @@ name = Astro Code School
 [http://www.toolness.com/wp/?cat=11&feed=rss2]
 name = Atul Varma -- Toolness
 
-[http://www.codemakesmehappy.com/feeds/posts/default/-/Python]
+[https://audrey.roygreenfeld.com/feeds/posts/default/-/Python]
 name = Audrey Roy Greenfeld
 
 [http://automatingosint.com/blog/category/python/feed/]
@@ -426,7 +426,7 @@ name = Daniel Bader
 [http://danielnouri.org/notes/category/python/feed/index.xml]
 name = Daniel Nouri
 
-[https://www.pydanny.com/feeds/python.atom.xml]
+[https://daniel.roygreenfeld.com/feeds/python.atom.xml]
 name = Daniel Roy Greenfeld
 
 [http://www.gefira.pl/blog/tag/planet-python/feed/]


### PR DESCRIPTION
# EDIT FEED
-------------------------------------------------------------------------------

Hi, I want to change me and my wife's current feed url from:

* Audrey: http://www.codemakesmehappy.com/feeds/posts/default/-/Python to https://audrey.roygreenfeld.com/feeds/posts/default/-/Python
* Daniel: https://www.pydanny.com/feeds/python.atom.xml to https://daniel.roygreenfeld.com/feeds/python.atom.xml

## I checked the following required validations for bth feeds: (mark all 5 with [x])

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=MY_FEED_URL and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)
5. [x] My feed contains only content in English language.

Thanks in advance for editing our feeds on PythonPlanet! :+1:
