### PR TITLE
Add https://davidcaron.dev

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -447,6 +447,9 @@ name = Dataquest
 [http://dabeaz.blogspot.com/feeds/posts/default]
 name = Dave Beazley
 
+[https://davidcaron.dev/feeds/tags/python.atom.xml]
+name = David Caron
+
 [http://www.artima.com/weblogs/feeds/bloggers/goodger.rss]
 name = David Goodger
 


### PR DESCRIPTION
Fixes #397

Hi, I want to add my feed to the Python Planet https://davidcaron.dev

**My Name/Blog Name**: David Caron

**My Blog ATOM Python specific feed url**: https://davidcaron.dev/feeds/tags/python.atom.xml
 
## I checked the following required validations:

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=https://davidcaron.dev/feeds/tags/python.atom.xml and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)
5. [x] My feed contains only content in English language.

Thanks in advance for adding my feed to the PythonPlanet! :+1: