### PR TITLE
Add Python Morsels feed

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -1527,6 +1527,9 @@ name = Python Engineering at Microsoft
 [http://feeds.feedburner.com/PythonInsider]
 name = Python Insider
 
+[https://www.pythonmorsels.com/topics/feed/]
+name = Python Morsels
+
 [http://python-open-mike.posterous.com/rss.xml]
 name = Python Open Mike
 


### PR DESCRIPTION
Hi, I want to add my feed to the Python Planet. or I want to change my current feed url from CURRENT_URL_HERE to NEW_URL_HERE

Closes #406

## I checked the following required validations:

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=MY_FEED_URL and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)
5. [x] My feed contains only content in English language.

Thanks in advance for adding my feed to the PythonPlanet! :+1:

