### PR TITLE
Adds Zero To Mastery's Pythons Feed

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -2195,3 +2195,6 @@ name = Éric Araujo
 
 [http://lukasz.langa.pl/feed/tag/python/rss-en.xml]
 name = Łukasz Langa
+
+[https://zerotomastery.io/rss/python-rss.xml]
+name = Zero To Mastery


### PR DESCRIPTION
closes #423 

Hi, I would like to add my feed to the Python Planet

**Blog Name**: Zero To Mastery 

**Blog RSS or ATOM Python specific feed url**: https://zerotomastery.io/rss/python-rss.xml

> IMPORTANT!!! **we need contact information to notify in case of any changes** Please send an email to `planet@python.org` title: `PR {number} sent to planet` with your email address + a link for the PR you opened.
 
## I checked the following required validations:

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fzerotomastery.io%2Frss%2Fpython-rss.xml and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)
5. [x] My feed contains only content in English language.

Thanks in advance for adding my feed to the PythonPlanet! :+1:

~~> NOTE: If you are adding a podcast feed please validate using http://castfeedvalidator.com/~~