### PR TITLE
Fixed dead links and synced full view with titles-only

### DIFF
--- a/config/index.html.tmpl
+++ b/config/index.html.tmpl
@@ -95,13 +95,12 @@ src="/static/images/python-logo.gif" alt="homepage" border="0" /></a>
               <li><a href="http://terri.toybox.ca/python-soc/">Python Summer of Code</a></li>
               <li><a href="http://www.afpy.org/planet/">Planet Python Francophone</a></li>
               <li><a href="http://planeta.python.org.ar/">Planet Python Argentina</a></li>
-              <li><a href="http://planetpython.matrix.jp/planet/">Planet Python Japan</a></li>
               <li><a href="http://wiki.python.org.br/planet/">Planet Python Brasil</a></li>
-              <li><a href="http://planet.python.or.id">Planet Python Indonesia</a></li>
               <li><a href="http://pl.python.org/planeta/">Planet Python Poland</a></li>
   	  </ul></li>
 	  <li>Python Libraries
           <ul class="level-two">
+            <li><a href="http://planet.laptop.org/">OLPC</a></li>
             <li><a href="http://planet.pysoy.org/">PySoy</a></li>
             <li><a href="http://planet.scipy.org/">SciPy</a></li>
             <li><a href="http://planet.sympy.org/">SymPy</a></li>

--- a/config/titles_only.html.tmpl
+++ b/config/titles_only.html.tmpl
@@ -81,8 +81,8 @@ src="/static/images/python-logo.gif" alt="homepage" border="0" /></a>
               <li><a href="http://terri.toybox.ca/python-soc/">Python Summer of Code</a></li>
               <li><a href="http://www.afpy.org/planet/">Planet Python Francophone</a></li>
               <li><a href="http://planeta.python.org.ar/">Planet Python Argentina</a></li>
-              <li><a href="http://planetpython.matrix.jp/planet/">Planet Python Japan</a></li>
               <li><a href="http://wiki.python.org.br/planet/">Planet Python Brasil</a></li>
+              <li><a href="http://pl.python.org/planeta/">Planet Python Poland</a></li>
   	  </ul></li>
 	  <li>Python Libraries
           <ul class="level-two">


### PR DESCRIPTION
This performs the following changes

* Removed unreachable Planet Python Japan and Planet Python Indonesia
* Added Planet Python Poland to the titles only view
* Added http://planet.laptop.org to the full view
