### PR TITLE
Kindly add PythonTrainingHQ's feed

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -1497,6 +1497,9 @@ name = PyCon.DE & PyData Karlsruhe
 [http://morepypy.blogspot.com/feeds/posts/default]
 name = PyPy Development
 
+[https://www.pythontraininghq.com/feed/]
+name = PythonTrainingHQ
+
 [http://pytennessee.tumblr.com/rss]
 name = PyTennessee
 


### PR DESCRIPTION
Hi, I want to add my blog's feed to the Python Planet.

**My blog's name**: PythonTrainingHQ

**My Blog RSS or ATOM Python specific feed url**: https://www.pythontraininghq.com/feed/ 

**I checked the following required validations:**

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=https://www.pythontraininghq.com/feed/ and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)
5. [x] My feed contains only content in English language.

Thanks in advance for adding my feed to the PythonPlanet! :+1: