### PR TITLE
Update feed URL for Ram Rachum's blog (Fix #418)

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -1629,7 +1629,7 @@ name = Ralph Bean
 [http://www.ralph-heinkel.com/blog/category/python/feed/atom/index.xml]
 name = Ralph Heinkel
 
-[http://feeds.feedburner.com/RamRachumsBlog/planetpython]
+[https://blog.ram.rachum.com/tagged/planetpython/rss]
 name = Ram Rachum
 
 [http://blog.randell.ph/tag/python/feed/atom/]


### PR DESCRIPTION
# EDIT FEED
-------------------------------------------------------------------------------

I want to change my current feed url from http://feeds.feedburner.com/RamRachumsBlog/planetpython to http://feeds.feedburner.com/RamRachumsBlog/planetpython

## I checked the following required validations:

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=MY_FEED_URL and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)
5. [x] My feed contains only content in English language.

Thanks in advance for adding my feed to the PythonPlanet! :+1:

