### PR TITLE
Add feed for cusy, #447

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -402,6 +402,9 @@ name = CubicWeb
 [https://ntguardian.wordpress.com/category/python/feed/]
 name = Curtis Miller
 
+[https://cusy.io/en/blog/python/atom.xml]
+name = Cusy
+
 [http://dspillustrations.com/static/dspillustrations.rss.xml]
 name = DSPIllustrations.com
 


### PR DESCRIPTION
# ADD FEED
-------------------------------------------------------------------------------

Hi, I want to add my feed to the Python Planet

**My Name/Blog Name**: Cusy

**My Blog RSS or ATOM Python specific feed url**: https://cusy.io/en/blog/python/atom.xml
 
## I checked the following required validations: (mark all 5 with [x])

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=MY_FEED_URL and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)
5. [x] My feed contains only content in English language.

Thanks in advance for adding my feed to the PythonPlanet! :+1: