### PR TITLE
Please add death.andgravity.com

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -2187,6 +2187,9 @@ name = codeboje
 [http://codingdirectional.info/category/python/feed/]
 name = codingdirectional
 
+[https://death.andgravity.com/_feed/index/_tags/python.xml]
+name = death and gravity
+
 [http://www.egenix.com/company/news/rss2]
 name = eGenix.com
 


### PR DESCRIPTION
Hi, I want to add my feed to the Python Planet.

**My Name/Blog Name**: death and gravity

**My Blog RSS or ATOM Python specific feed url**: https://death.andgravity.com/_feed/index/_tags/python.xml

> IMPORTANT!!! **we need contact information to notify in case of any changes** Please send an email to `planet@python.org` title: `PR {number} sent to planet` with your email address + a link for the PR you opened.
 
## I checked the following required validations: (mark all 5 with [x])

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fdeath.andgravity.com%2F_feed%2Findex%2F_tags%2Fpython.xml and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)
5. [x] My feed contains only content in English language.

Thanks in advance for adding my feed to the PythonPlanet! :+1:
