### PR TITLE
pypy blogposts have moved

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -1518,8 +1518,8 @@ name = PyCon Pune
 [http://de.pycon.org/feed.xml]
 name = PyCon.DE & PyData Karlsruhe
 
-[http://morepypy.blogspot.com/feeds/posts/default]
-name = PyPy Development
+[https://www.pypy.org/rss.xml]
+name = PyPy
 
 [https://www.pythontraininghq.com/feed/]
 name = PythonTrainingHQ


### PR DESCRIPTION
# ADD FEED / EDIT FEED
-------------------------------------------------------------------------------

Hi, I want to add my feed to the Python Planet. or I want to change my current feed url from morepypy.blogspot.com to ppy.org/blog

## I checked the following required validations: (mark all 5 with [x])

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=MY_FEED_URL and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)
5. [x] My feed contains only content in English language.

Thanks in advance for adding my feed to the PythonPlanet! :+1:

> NOTE: If you are adding a podcast feed please validate using http://castfeedvalidator.com/


