### PR TITLE
Update config.ini: fix feed link for Chris Hager

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -288,7 +288,7 @@ name = Checking and Sharing
 [https://chinghwayu.com/category/python/feed/]
 name = Ching-Hwa Yu
 
-[http://metachris.org/category/python/feed/atom/]
+[https://www.metachris.com/tags/python/index.xml]
 name = Chris Hager
 
 [http://blog.cdleary.com/category/programming/python/feed/]


### PR DESCRIPTION
# EDIT FEED
-------------------------------------------------------------------------------

Hi, I want to add my feed to the Python Planet. or I want to change my current feed url from http://metachris.org/category/python/feed/atom/ to https://www.metachris.com/tags/python/index.xml

## I checked the following required validations: (mark all 5 with [x])

1. [X] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=MY_FEED_URL and it is valid!
2. [X] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [X] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [X] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)
5. [X] My feed contains only content in English language.

Thanks in advance for adding my feed to the PythonPlanet! :+1:

> NOTE: If you are adding a podcast feed please validate using http://castfeedvalidator.com/


