### PR TITLE
Revert 'Added AI Pool Python Feed (#468)'

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -24,9 +24,6 @@ name = A. Jesse Jiryu Davis
 [http://ablog.readthedocs.org/blog/atom.xml]
 name = ABlog for Sphinx
 
-[https://ai-pool.com/feed.xml]
-name = AI Pool
-
 [http://www.artima.com/weblogs/feeds/bloggers/aahz.rss]
 name = Aahz
 


### PR DESCRIPTION
This reverts commit c00d71b93d2df20ce1260e951ef72619ce2ceea9.

Please remove this feed, it does not contain actual articles but spams the planet with questions.

Note that it doesn't seem to violate any of the rules for inclusion - all items in the feed appear to be somewhat related to Python and use English as the language, however, the very low signal to noise ratio is inspiring me to open this PR. Is there a need to expand the rules in this regard?