### PR TITLE
update feed url

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -549,7 +549,7 @@ name = Ionel Cristian Maries
 [http://ironpython-urls.blogspot.com/feeds/posts/default]
 name = IronPython-URLs
 
-[https://onmouseentered.com/category/python/feed/]
+[https://islandtropicaman.com/wp/category/python/feed/]
 name = IslandT
 
 [http://fruch.github.io/feed.python.xml]


### PR DESCRIPTION
# EDIT FEED
-------------------------------------------------------------------------------

Hi, I want to change my current feed url from [https://onmouseentered.com/category/python/feed/] to [https://islandtropicaman.com/wp/category/python/feed/]

## I checked the following required validations: (mark all 5 with [x])

1. [x ] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=https://islandtropicaman.com/wp/category/python/feed/ and it is valid!
2. [x ] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [ x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)
5. [x ] My feed contains only content in English language.

Thanks in advance for adding my feed to the PythonPlanet! :+1:


