### PR TITLE
Update config.ini to reflect new Janusworx feed

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -588,7 +588,7 @@ name = Jamal Moir
 [https://www.b-list.org/feeds/entries/]
 name = James Bennett
 
-[https://janusworx.com/categories/planetpython.xml]
+[https://janusworx.com/tags/planetpython/index.xml]
 name = Janusworx
 
 [http://blog.jarrodmillman.com/feeds/posts/default/-/python]


### PR DESCRIPTION

Hi, I want to add my feed to the Python Planet. or I want to change my current feed url from `https://janusworx.com/categories/planetpython.xml` to `https://janusworx.com/tags/planetpython/index.xml`

## I checked the following required validations: (mark all 5 with [x])

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=MY_FEED_URL and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)
5. [x] My feed contains only content in English language.

Thanks in advance for adding my feed to the PythonPlanet! :+1:




