### PR TITLE
Remove two problematic feeds per issue #502, point (1)

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -561,9 +561,6 @@ name = Israel Fruchter
 [http://codewithoutrules.com/python-atom.xml]
 name = Itamar Turner Trauring
 
-[https://itsmycode.com/category/python/feed/atom/]
-name = ItsMyCode
-
 [https://iximiuz.com/feed-python.atom]
 name = Ivan Velichko
 
@@ -1136,9 +1133,6 @@ name = Python Sweetness
 
 [http://python-groups.blogspot.com/feeds/posts/default]
 name = Python User Groups
-
-[https://www.pythonforbeginners.com/feed/]
-name = Python for Beginners
 
 [http://python-karan.blogspot.in//feeds/posts/default]
 name = Python on Karan


### PR DESCRIPTION
Delete poorly conceived and spammy feeds "Python for Beginners" and "It's My Code" as described in issue #502 and ensuing discussion.

This change proposal does not purport to resolve issue #502 in its entirety, as there may be other problematic feeds.  Additional analysis is required on that point. Furthermore, that issue also suggests in point (2) that an attestation be required of authors that their postings are formatted in the spirit of PEP8, which this change proposal does not address.

Be that as it may, accepting this proposal will immediately improve the quality of content for those browsing the planet and, in particular, will stop the planet from misleading beginners with two low quality, un-Pythonic, spammy feeds.