### PR TITLE
Add Declassed Art

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -357,6 +357,9 @@ name = Davy Mitchell
 [http://davywybiral.blogspot.com/feeds/posts/default]
 name = Davy Wybiral
 
+[https://declassed.art/en/feed/python.xml]
+name = Declassed Art
+
 [http://makkalot-opensource.blogspot.com/feeds/posts/default/-/python]
 name = Denis Kurov
 


### PR DESCRIPTION
Hi, I want to add my feed to the Python Planet.

## I checked the following required validations: (mark all 5 with [x])

1. [x] My feed is valid, I checked using http://validator.w3.org/feed/check.cgi?url=https%3A//declassed.art/en/feed/python.xml and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)
5. [x] My feed contains only content in English language.

Thanks in advance for adding my feed to the PythonPlanet! :+1: