### PR TITLE
Remove Quansight Labs blog, its feed is not working

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -1170,9 +1170,6 @@ name = Péter Szabó
 [http://blog.zsoldosp.eu/category/python/feed/]
 name = Péter Zsoldos
 
-[https://labs.quansight.org/rss.xml]
-name = Quansight Labs Blog
-
 [http://www.bitdance.com/blog/rss.xml]
 name = R David Murray
 


### PR DESCRIPTION
Closes gh-517

The issue has been open for too long already, let's not wait for a fix on the RSS feed but just remove it. It can always be re-added in the future.