### PR TITLE
Remove Django Weekly (site is dead)

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -366,9 +366,6 @@ name = Denis Kurov
 [http://www.djangoproject.com/rss/weblog/]
 name = Django Weblog
 
-[http://djangoweekly.com/blog/feed/]
-name = Django Weekly
-
 [https://djangostars.com/blog/category/python/feed/]
 name = Djangostars
 


### PR DESCRIPTION
The Django Weekly site is no longer available, so the RSS feed should be removed.