### PR TITLE
update url for doughellmann.com

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -372,7 +372,7 @@ name = Djangostars
 [http://doingmathwithpython.github.io/feeds/all.atom.xml]
 name = Doing Math with Python
 
-[http://feeds.doughellmann.com/doughellmann/python]
+[https://feeds.feedburner.com/doughellmann/python]
 name = Doug Hellmann
 
 [http://www.dougalmatthews.com/feeds/python.atom.xml]


### PR DESCRIPTION
I want to change my current feed url from http://feeds.doughellmann.com/doughellmann/python to https://feeds.feedburner.com/doughellmann/python

I changed my site hosting recently, and the vanity domain for
feedburner broke in the process. This updates the feed URL to point to
the right canonical location.

## I checked the following required validations: (mark all 5 with [x])

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=MY_FEED_URL and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)
5. [x] My feed contains only content in English language.

Thanks in advance for updating my feed on PythonPlanet! :+1: