### PR TITLE
Update feed URL for wyattbaldwin.com

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -1548,7 +1548,7 @@ name = Wing Tips
 [http://wingware.com/news/rss&noheader=1]
 name = Wingware
 
-[https://wyattbaldwin.com/categories/planet-python/index.xml]
+[https://wyattbaldwin.com/categories/planet-python/rss.xml]
 name = Wyatt Baldwin
 
 [http://tech.blog.aknin.name/tag/python/feed/atom/]


### PR DESCRIPTION
# ADD FEED / EDIT FEED
-------------------------------------------------------------------------------

I want to change my current feed URL from https://wyattbaldwin.com/categories/planet-python/index.xml to https://wyattbaldwin.com/categories/planet-python/rss.xml

## I checked the following required validations: (mark all 5 with [x])

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=https://wyattbaldwin.com/categories/planet-python/rss.xml and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)
5. [x] My feed contains only content in English language.

Thanks in advance for updating my PythonPlanet feed URL! :+1:

