### PR TITLE
add PythonPeople.fm podcast

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -1119,6 +1119,9 @@ name = Python Insider
 [https://www.pythonmorsels.com/topics/feed/]
 name = Python Morsels
 
+[https://pythonpeople.fm/rss]
+name = Python People
+
 [http://www.pyptug.org/feeds/posts/default/]
 name = Python Piedmont Triad User Group
 


### PR DESCRIPTION
Hi, I want to add my feed to the Python Planet. 

## I checked the following required validations: (mark all 5 with [x])

1. [x] My feed is valid, I checked using https://www.castfeedvalidator.com/?url=https://pythonpeople.fm/rss and it is valid!
2. [x] My feed is a **Python Specific** feed.
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)
5. [x] My feed contains only content in English language.

Thanks in advance for adding my feed to the PythonPlanet! :+1:

> NOTE: If you are adding a podcast feed please validate using http://castfeedvalidator.com/

This closes issue #548 



