### PR TITLE
Fix wrong closing character in config.ini

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -1647,5 +1647,5 @@ name = Éric Araujo
 [https://lukasz.langa.pl/python/atom.xml]
 name = Łukasz Langa
 
-[https://www.pythonshow.com/feed}
+[https://www.pythonshow.com/feed]
 name = The Python Show


### PR DESCRIPTION
# FIX FEED BUG
-------------------------------------------------------------------------------

Fixes https://github.com/python/planet/issues/562 by changing closing `}` to `]` in `config.ini`.
