### PR TITLE
Add Python feed of bugfactory.io

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -1652,3 +1652,6 @@ name = The Python Show
 
 [https://stefaniemolin.com/feeds/Python-atom.xml]
 name = Stefanie Molin
+
+[https://bugfactory.io/articles-on-python/feed.xml]
+name = Christoph Schiessl


### PR DESCRIPTION
# ADD FEED
-------------------------------------------------------------------------------

Hi, I want to add my feed to the Python Planet. 

## I checked the following required validations: (mark all 5 with [x])

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=https://bugfactory.io/articles-on-python/feed.xml and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)
5. [x] My feed contains only content in English language.

Thanks in advance for adding my feed to the PythonPlanet! :+1: