### PR TITLE
Fix the feed location for my site

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -303,7 +303,7 @@ name = Chris Mitchell
 [http://pbpython.com/feeds/all.atom.xml]
 name = Chris Moffitt
 
-[http://ideas.offby1.net/feeds/tag-python.atom.xml]
+[http://offby1.website/feeds/tag-python.atom.xml]
 name = Chris Rose
 
 [http://feeds.feedburner.com/ChrisWarrickPython]


### PR DESCRIPTION
# EDIT FEED
-------------------------------------------------------------------------------

Hi, I want to change my current feed url from https://ideas.offby1.net/feeds/tag-python.atom.xml to https://offby1.website/feeds/tag-python.atom.xml

## I checked the following required validations: (mark all 5 with [x])

1. [X] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=https://offby1.website/feeds/tag-python.atom.xml and it is valid!
2. [X] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [X] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [X] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)
5. [X] My feed contains only content in English language.

Thanks in advance for adding my feed to the PythonPlanet! :+1:

> NOTE: If you are adding a podcast feed please validate using http://castfeedvalidator.com/


