### PR TITLE
Fix URL for pydanny site

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -318,7 +318,7 @@ name = Daniel Bader
 [http://danielnouri.org/notes/category/python/feed/index.xml]
 name = Daniel Nouri
 
-[https://daniel.roygreenfeld.com/feeds/python.atom.xml]
+[https://daniel.feldroy.com/feeds/python.atom.xml]
 name = Daniel Roy Greenfeld
 
 [http://www.datacommunitydc.org/blog?format=RSS&tag=python]


### PR DESCRIPTION
# ADD FEED / EDIT FEED
-------------------------------------------------------------------------------

Hi, I want to add my feed to the Python Planet. or I want to change my current feed url from [https://daniel.roygreenfeld.com/feeds/python.atom.xml](https://daniel.roygreenfeld.com/feeds/python.atom.xml) to [https://daniel.feldroy.com/feeds/python.atom.xml](https://daniel.feldroy.com/feeds/python.atom.xml)

## I checked the following required validations: (mark all 5 with [x])

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=MY_FEED_URL and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)
5. [x] My feed contains only content in English language.

Thanks in advance for adding my feed to the PythonPlanet! :+1:

> NOTE: If you are adding a podcast feed please validate using http://castfeedvalidator.com/


