### PR TITLE
Check config.ini is sorted with GitHub Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: Lint
+
+on: [push, pull_request, workflow_dispatch]
+
+permissions: {}
+
+env:
+  FORCE_COLOR: 1
+  RUFF_OUTPUT_FORMAT: github
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - uses: tox-dev/action-pre-commit-uv@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: sort-ini
+        name: Sort config.ini
+        entry: python3 config/sort-ini.py config/config.ini
+        language: python
+        pass_filenames: false
+        files: ^config/config.ini$


### PR DESCRIPTION
Follow on from https://github.com/python/planet/pull/591 where we discovered `config.ini` was no longer sorted.

This PR runs `sort-ini.py` on the CI and will fail if there was a change.

Here's an example failure: https://github.com/hugovk/planet/actions/runs/13658725429/job/38184489758

And an example pass: https://github.com/hugovk/planet/actions/runs/13658738341/job/38184533998

---

Optionally, we could enable https://pre-commit.ci/ on this repo and it will auto-update unsorted PRs.
