### PR TITLE
Fix Python Brasil link

### DIFF
--- a/config/index.html.tmpl
+++ b/config/index.html.tmpl
@@ -92,7 +92,7 @@ src="/static/images/python-logo.gif" alt="homepage" border="0" /></a>
               <li><a href="http://terri.toybox.ca/python-soc/">Python Summer of Code</a></li>
               <li><a href="http://www.afpy.org/planet/">Planet Python Francophone</a></li>
               <li><a href="http://planeta.python.org.ar/">Planet Python Argentina</a></li>
-              <li><a href="http://wiki.python.org.br/planet/">Planet Python Brasil</a></li>
+              <li><a href="http://planet.python.org.br/">Planet Python Brasil</a></li>
               <li><a href="http://pl.python.org/planeta/">Planet Python Poland</a></li>
   	  </ul></li>
 	  <li>Python Libraries

--- a/config/titles_only.html.tmpl
+++ b/config/titles_only.html.tmpl
@@ -78,7 +78,7 @@ src="/static/images/python-logo.gif" alt="homepage" border="0" /></a>
               <li><a href="http://terri.toybox.ca/python-soc/">Python Summer of Code</a></li>
               <li><a href="http://www.afpy.org/planet/">Planet Python Francophone</a></li>
               <li><a href="http://planeta.python.org.ar/">Planet Python Argentina</a></li>
-              <li><a href="http://wiki.python.org.br/planet/">Planet Python Brasil</a></li>
+              <li><a href="http://planet.python.org.br/">Planet Python Brasil</a></li>
               <li><a href="http://pl.python.org/planeta/">Planet Python Poland</a></li>
   	  </ul></li>
 	  <li>Python Libraries


### PR DESCRIPTION
Hello,

A while ago we moved the planet feed from the Brazilian community from the subpath of our wiki to its own subdomain planet.python.org.br

So this PR updates planet python to the new link :slightly_smiling_face: 

