### PR TITLE
First Institute RSS Python feed added

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -438,6 +438,9 @@ name = Filip Wasilewski
 [http://blog.filipesaraiva.info/?feed=rss2&tag=planet-python]
 name = Filipe Saraiva
 
+[https://first.institute/en/rss/python/]
+name = First Institute of Reliable Software
+
 [http://pyinsci.blogspot.com/feeds/posts/default]
 name = Flavio Coelho
 


### PR DESCRIPTION
# ADD FEED
-------------------------------------------------------------------------------

Hi, I want to add my feed to the Python Planet.

```
[https://first.institute/en/rss/python/]
name = First Institute of Reliable Software
```

## I checked the following required validations: (mark all 5 with [x])

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=https://first.institute/en/rss/python/ and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)
5. [x] My feed contains only content in English language.

Thanks in advance for adding my feed to the PythonPlanet! :+1:

