### PR TITLE
Update mathspp/Rodrigo Girao Serrao feed.

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -831,9 +831,6 @@ name = Martijn Pieters
 [https://www.mfitzp.com/feeds/python.tag.atom.xml]
 name = Martin Fitzpatrick
 
-[https://mathspp.com/blog/pydonts.rss]
-name = "Mathspp Pydon'ts"
-
 [http://mysqlmusings.blogspot.se/feeds/posts/default/-/python]
 name = Mats Kindahl
 
@@ -1274,6 +1271,9 @@ name = Robin Wilson
 
 [http://linil.wordpress.com/feed/atom/]
 name = Rodrigo Araúj
+
+[https://mathspp.com/blog/tags/python.rss]
+name = Rodrigo Girão Serrão
 
 [https://www.rosehosting.com/blog/tag/python/feed/]
 name = RoseHosting Blog


### PR DESCRIPTION
# EDIT FEED
-------------------------------------------------------------------------------

I want to change my current feed url from mathspp.com/blog/pydonts to https://mathspp.com/blog/tags/python.rss so that the feed subscribed to captures all my Python-related writing instead of just the Pydon'ts.

## I checked the following required validations: (mark all 5 with [x])

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=https://mathspp.com/blog/tags/python.rss and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)
5. [x] My feed contains only content in English language.

Thanks in advance for adding my feed to the PythonPlanet! :+1:
