### PR TITLE
Fix info about adding/removing feeds.

### DIFF
--- a/config/titles_only.html.tmpl
+++ b/config/titles_only.html.tmpl
@@ -117,8 +117,13 @@ src="/static/images/python-logo.gif" alt="homepage" border="0" /></a>
 <li><a href="<TMPL_VAR link ESCAPE="HTML">" title="<TMPL_VAR title ESCAPE="HTML">"><TMPL_VAR name></a>
 </li>
 </TMPL_LOOP>
-<li> <i>To request addition or removal:<br />
-e-mail planet at python.org (note, responses can take up to a few days)</i></li>
+
+<li>
+    <i>
+    To request addition or removal:<br />
+    Open an issue on <a href="https://github.com/python/planet/issues">github</a><br />
+    </i>
+</li>
           </ul></li>
       </ul>
     </div>


### PR DESCRIPTION
One of the pages shows the correct info about using GH to add/edit/remove feeds while the other page shows a note about using an email address that isn't active right now (I know because I just wrote an email to that address requesting the change that I just proposed directly with PR #600.)

This PR replaces the old e-mail-based instructions with the new GH-based instructions.