### PR TITLE
Update feed URL for Graham Dumpleton.

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -504,7 +504,7 @@ name = Godson Gera
 [http://www.curiousvenn.com/?feed=rss2&cat=4]
 name = Graeme Cross
 
-[http://blog.dscpl.com.au/feeds/posts/default]
+[https://grahamdumpleton.me/feed.xml]
 name = Graham Dumpleton
 
 [https://www.grahamwheeler.com/categories/python.xml]


### PR DESCRIPTION
# EDIT FEED

Hi, I want to change my current feed url from http://blog.dscpl.com.au/feeds/posts/default
 to https://grahamdumpleton.me/feed.xml

## I checked the following required validations: (mark all 5 with [x])

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=MY_FEED_URL and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)
5. [x] My feed contains only content in English language.

Thanks in advance for adding my feed to the PythonPlanet! :+1:


