### PR TITLE
Add loopwerk.io RSS feed (Kevin Renskers)

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -714,6 +714,9 @@ name = Kay Schluehr
 [http://kbyanc.blogspot.com/feeds/posts/default/-/python]
 name = Kelly Yancey
 
+[https://www.loopwerk.io/articles/tag/python/feed.xml]
+name = Kevin Renskers
+
 [https://kodnito.com/python/rss/]
 name = Kodnito
 


### PR DESCRIPTION
## Summary
Adds the Python-specific RSS feed from loopwerk.io (Kevin Renskers) to Planet Python.

## Details
- **Feed URL**: https://www.loopwerk.io/articles/tag/python/feed.xml
- **Author**: Kevin Renskers
- **Content**: High-quality Django and Python articles
- **Language**: English only
- **Feed type**: Atom (validated)
- **Recent activity**: 10 articles (July-December 2025)

## Recent articles include:
- Safe Django migrations without server errors
- Async Django: a solution in search of a problem?
- Run Django tests using PostgreSQL in GitHub Actions

Closes #611