### PR TITLE
Add PyCon Ireland 2026 feed

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -1116,6 +1116,9 @@ name = PyCoder’s Weekly
 [http://feeds.feedburner.com/PyCon]
 name = PyCon
 
+[https://2026.pycon.ie/blog/index.xml]
+name = PyCon Ireland 2026
+
 [https://pypodcats.live/episodes/index.xml]
 name = PyPodcats
 

--- a/config/config.ini
+++ b/config/config.ini
@@ -1117,7 +1117,7 @@ name = PyCoder’s Weekly
 name = PyCon
 
 [https://2026.pycon.ie/blog/index.xml]
-name = PyCon Ireland 2026
+name = PyCon Ireland
 
 [https://pypodcats.live/episodes/index.xml]
 name = PyPodcats


### PR DESCRIPTION
## Summary

- Adds the RSS feed for PyCon Ireland 2026 (`https://2026.pycon.ie/blog/index.xml`)